### PR TITLE
feat(marketing-landing): build WeHire marketing landing page

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -15,6 +15,6 @@ Tracked issues for **WeHire**. Source of truth is GitHub Issues — this file is
 | 005 | Add Zod schema validation to application form fields | `done` | [#5](https://github.com/handharr-labs/wehire/issues/5) |
 | 006 | Write unit and ViewModel hook tests for career-microsite feature | `done` | [#6](https://github.com/handharr-labs/wehire/issues/6) |
 | 007 | Implement subdomain routing middleware for branded career pages | `done` | [#7](https://github.com/handharr-labs/wehire/issues/7) |
-| 008 | Enforce plan job limit and surface 'not hiring' state on career page | `pending` | [#8](https://github.com/handharr-labs/wehire/issues/8) |
-| 009 | Build WeHire marketing landing page | `open` | [#9](https://github.com/handharr-labs/wehire/issues/9) |
+| 008 | Enforce plan job limit and surface 'not hiring' state on career page | `done` | [#8](https://github.com/handharr-labs/wehire/issues/8) |
+| 009 | Build WeHire marketing landing page | `pending` | [#9](https://github.com/handharr-labs/wehire/issues/9) |
 | 010 | Document environment variable setup and create .env.example | `open` | [#10](https://github.com/handharr-labs/wehire/issues/10) |

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,11 @@
+import { Metadata } from 'next';
+import { MarketingLandingView } from '@/features/marketing-landing/presentation/MarketingLandingView';
+
+export const metadata: Metadata = {
+  title: 'WeHire — Branded Career Pages for Small Businesses',
+  description: 'Launch your own recruitment microsite in minutes. No code needed.',
+};
+
 export default function HomePage() {
-  return (
-    <main className="min-h-screen bg-zinc-50 flex items-center justify-center">
-      <div className="max-w-xl mx-auto px-4 text-center">
-        <h1 className="text-4xl font-bold text-zinc-900 mb-4">WeHire</h1>
-        <p className="text-zinc-500 text-lg mb-8">
-          Branded recruitment microsites for small businesses in Indonesia.
-        </p>
-        <p className="text-zinc-400 text-sm">
-          Visit <code className="bg-zinc-100 px-1 rounded">/{'{'}your-company{'}'}</code> to see your career page.
-        </p>
-      </div>
-    </main>
-  );
+  return <MarketingLandingView />;
 }

--- a/src/features/marketing-landing/presentation/MarketingLandingView.tsx
+++ b/src/features/marketing-landing/presentation/MarketingLandingView.tsx
@@ -1,0 +1,29 @@
+import { HeroSection } from './sections/HeroSection';
+import { FeaturesSection } from './sections/FeaturesSection';
+import { BottomCtaSection } from './sections/BottomCtaSection';
+
+export function MarketingLandingView() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <nav className="flex items-center justify-between px-6 py-4 border-b border-zinc-100 bg-white">
+        <span className="font-bold text-zinc-900 text-lg">WeHire</span>
+        <a
+          href="#request-access"
+          className="text-sm font-semibold text-indigo-600 hover:text-indigo-700 transition-colors"
+        >
+          Get Started
+        </a>
+      </nav>
+
+      <main className="flex-1">
+        <HeroSection />
+        <FeaturesSection />
+        <BottomCtaSection />
+      </main>
+
+      <footer className="text-zinc-400 text-sm text-center py-8">
+        © 2025 WeHire · Mekari Talenta
+      </footer>
+    </div>
+  );
+}

--- a/src/features/marketing-landing/presentation/__tests__/MarketingLandingView.test.tsx
+++ b/src/features/marketing-landing/presentation/__tests__/MarketingLandingView.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarketingLandingView } from '../MarketingLandingView';
+
+describe('MarketingLandingView', () => {
+  it('renders H1 headline containing "your brand"', () => {
+    render(<MarketingLandingView />);
+    expect(screen.getByRole('heading', { level: 1, name: /your brand/i })).toBeTruthy();
+  });
+
+  it('renders "Get Started" CTA link', () => {
+    render(<MarketingLandingView />);
+    const links = screen.getAllByRole('link', { name: /get started/i });
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it('renders all three feature card titles', () => {
+    render(<MarketingLandingView />);
+    expect(screen.getByText('Your Own Branded Microsite')).toBeTruthy();
+    expect(screen.getByText('Free to Start')).toBeTruthy();
+    expect(screen.getByText('Up and Running in Minutes')).toBeTruthy();
+  });
+
+  it('renders bottom CTA heading and Request Access link', () => {
+    render(<MarketingLandingView />);
+    expect(screen.getByRole('heading', { level: 2, name: /ready to launch/i })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /request access/i })).toBeTruthy();
+  });
+});

--- a/src/features/marketing-landing/presentation/sections/BottomCtaSection.tsx
+++ b/src/features/marketing-landing/presentation/sections/BottomCtaSection.tsx
@@ -1,0 +1,18 @@
+export function BottomCtaSection() {
+  return (
+    <section id="request-access" className="bg-indigo-600 text-white py-20 px-4 text-center">
+      <div className="max-w-2xl mx-auto">
+        <h2 className="text-3xl font-bold mb-4">Ready to launch your career page?</h2>
+        <p className="text-indigo-100 mb-8">
+          Request early access — we&apos;ll set up your microsite and onboard you personally.
+        </p>
+        <a
+          href="mailto:hello@wehire.id"
+          className="inline-block bg-white text-indigo-600 rounded-lg px-6 py-3 font-semibold hover:bg-indigo-50 transition-colors"
+        >
+          Request Access
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/features/marketing-landing/presentation/sections/FeaturesSection.tsx
+++ b/src/features/marketing-landing/presentation/sections/FeaturesSection.tsx
@@ -1,0 +1,50 @@
+const features = [
+  {
+    title: 'Your Own Branded Microsite',
+    description: 'Publish a career page at wehire.id/your-company with your logo and colors.',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="2" y1="12" x2="22" y2="12" />
+        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Free to Start',
+    description: 'Get your first career page live at no cost. Upgrade only when your team grows.',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3l1.5 4.5h4.5l-3.5 2.5 1.5 4.5L12 12l-4 2.5 1.5-4.5L6 7.5h4.5z" />
+        <path d="M5 20h14" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Up and Running in Minutes',
+    description: 'Fill in your details, add open roles, and share your link. That\u2019s it.',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+      </svg>
+    ),
+  },
+];
+
+export function FeaturesSection() {
+  return (
+    <section className="bg-white py-20 px-4">
+      <div className="max-w-5xl mx-auto">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+          {features.map((feature) => (
+            <div key={feature.title} className="bg-white rounded-xl border border-zinc-200 p-6">
+              <div className="text-indigo-600 mb-4">{feature.icon}</div>
+              <h3 className="font-semibold text-zinc-900 mb-2">{feature.title}</h3>
+              <p className="text-sm text-zinc-500">{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/marketing-landing/presentation/sections/HeroSection.tsx
+++ b/src/features/marketing-landing/presentation/sections/HeroSection.tsx
@@ -1,0 +1,20 @@
+export function HeroSection() {
+  return (
+    <section className="bg-gradient-to-b from-indigo-50 to-white">
+      <div className="max-w-2xl mx-auto px-4 py-24 text-center">
+        <h1 className="text-4xl font-bold text-zinc-900 mb-4 sm:text-5xl">
+          Your brand. Your career page. In minutes.
+        </h1>
+        <p className="text-lg text-zinc-500 mb-8">
+          WeHire gives small businesses in Indonesia a branded recruitment microsite — shareable, and free to start.
+        </p>
+        <a
+          href="#request-access"
+          className="inline-block bg-indigo-600 text-white rounded-lg px-6 py-3 font-semibold hover:bg-indigo-700 transition-colors"
+        >
+          Get Started
+        </a>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the dev placeholder at `/` with a proper marketing landing page (Hero → Features → CTA)
- Three static Server Components: `HeroSection`, `FeaturesSection`, `BottomCtaSection` assembled in `MarketingLandingView`
- Indigo brand palette (`bg-indigo-600`, gradient hero, white CTA button) — no `var(--brand-*)` vars
- Inline SVG icons only — no external icon library

## Test plan
- [x] `npm run test` — 4 new Vitest/RTL tests pass (34 total)
- [x] `npm run lint` — 0 errors
- [x] `npm run dev` → `http://localhost:3000` — landing page renders correctly
- [x] Check mobile viewport (375 px) — single column layout
- [x] Check desktop viewport (1280 px) — 3-column features grid
- [x] "Get Started" in nav and hero button scroll to `#request-access`
- [x] "Request Access" button opens `mailto:hello@wehire.id`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)