### PR TITLE
feat(#48): optimistic navigation + skeleton loading states

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -39,3 +39,4 @@ Tracked issues for **WeHire**. Source of truth is GitHub Issues — this file is
 | 042 | Fix Clean Architecture violations from arch review | `pending` | [#42](https://github.com/handharr-labs/wehire/issues/42) |
 | 044 | fix architecture violations: promote shared entities, fix cross-feature coupling, clean dead code | `pending` | [#44](https://github.com/handharr-labs/wehire/issues/44) |
 | 046 | fix all architecture violations and warnings from 2026-04-09 review | `pending` | [#46](https://github.com/handharr-labs/wehire/issues/46) |
+| 048 | feat: optimistic navigation + skeleton loading states across the project | `open` | [#48](https://github.com/handharr-labs/wehire/issues/48) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jose": "6.2.2",
         "next": "16.2.1",
         "next-safe-action": "8.1.8",
+        "nextjs-toploader": "^3.9.17",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "7.71.2",
@@ -7318,7 +7319,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7837,7 +7837,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8125,6 +8124,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
       "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.1",
         "@swc/helpers": "0.5.15",
@@ -8228,6 +8228,24 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nextjs-toploader": {
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/nextjs-toploader/-/nextjs-toploader-3.9.17.tgz",
+      "integrity": "sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "nprogress": "^0.2.0",
+        "prop-types": "^15.8.1"
+      },
+      "funding": {
+        "url": "https://buymeacoffee.com/thesgj"
+      },
+      "peerDependencies": {
+        "next": ">= 6.0.0",
+        "react": ">= 16.0.0",
+        "react-dom": ">= 16.0.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -8318,6 +8336,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
+    },
     "node_modules/nypm": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
@@ -8347,7 +8371,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8885,7 +8908,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9022,7 +9044,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jose": "6.2.2",
     "next": "16.2.1",
     "next-safe-action": "8.1.8",
+    "nextjs-toploader": "^3.9.17",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "7.71.2",

--- a/src/app/[slug]/jobs/[jobId]/apply/loading.tsx
+++ b/src/app/[slug]/jobs/[jobId]/apply/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function ApplyFormLoading() {
+  return (
+    <main className="min-h-screen bg-zinc-50">
+      <div className="max-w-2xl mx-auto px-4 py-10">
+        <Skeleton className="h-8 w-56 mb-2" />
+        <Skeleton className="h-4 w-32 mb-8" />
+
+        <div className="bg-white rounded-lg border border-zinc-200 p-8 space-y-5">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i}>
+              <Skeleton className="h-4 w-28 mb-1" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+          ))}
+          <Skeleton className="h-11 w-full rounded-lg" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/[slug]/jobs/[jobId]/loading.tsx
+++ b/src/app/[slug]/jobs/[jobId]/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function JobDetailLoading() {
+  return (
+    <main className="min-h-screen bg-zinc-50">
+      <div className="max-w-3xl mx-auto px-4 py-10">
+        <Skeleton className="h-4 w-32 mb-6" />
+
+        <div className="bg-white rounded-lg border border-zinc-200 p-8">
+          <Skeleton className="h-8 w-64 mb-2" />
+          <Skeleton className="h-4 w-80 mt-1" />
+          <Skeleton className="h-4 w-32 mt-2" />
+
+          <hr className="my-6 border-zinc-100" />
+
+          <section>
+            <Skeleton className="h-5 w-36 mb-3" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          </section>
+
+          <section className="mt-6">
+            <Skeleton className="h-5 w-28 mb-3" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          </section>
+
+          <div className="mt-8">
+            <Skeleton className="h-11 w-32 rounded-lg" />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/[slug]/loading.tsx
+++ b/src/app/[slug]/loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function CareerPageLoading() {
+  return (
+    <main className="min-h-screen bg-zinc-50">
+      <header className="bg-zinc-300 py-12">
+        <div className="max-w-3xl mx-auto px-4">
+          <Skeleton className="h-12 w-32 mb-4 bg-zinc-400" />
+          <Skeleton className="h-7 w-48 bg-zinc-400" />
+          <Skeleton className="h-4 w-72 mt-2 bg-zinc-400" />
+        </div>
+      </header>
+
+      <section className="max-w-3xl mx-auto px-4 py-10">
+        <Skeleton className="h-6 w-36 mb-6" />
+        <ul className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li key={i} className="bg-white rounded-lg border border-zinc-200 p-5">
+              <Skeleton className="h-5 w-48 mb-2" />
+              <Skeleton className="h-4 w-64" />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin/(protected)/dashboard/loading.tsx
+++ b/src/app/admin/(protected)/dashboard/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function AdminDashboardLoading() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-lg shadow p-6">
+          <Skeleton className="h-7 w-40 mb-4" />
+          <div className="flex gap-3 mb-4">
+            <Skeleton className="h-9 w-28" />
+            <Skeleton className="h-9 w-28" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/jobs/loading.tsx
+++ b/src/app/admin/(protected)/jobs/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function AdminJobsLoading() {
+  return (
+    <div className="bg-gray-50 min-h-screen p-8">
+      <div className="max-w-5xl mx-auto">
+        <Skeleton className="h-4 w-16 mb-4" />
+        <div className="bg-white rounded-lg shadow">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-9 w-24 rounded" />
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 border-b border-gray-200">
+                  {Array.from({ length: 7 }).map((_, i) => (
+                    <th key={i} className="px-6 py-3">
+                      <Skeleton className="h-3 w-16" />
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i}>
+                    {Array.from({ length: 7 }).map((_, j) => (
+                      <td key={j} className="px-6 py-4">
+                        <Skeleton className="h-4 w-24" />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/settings/loading.tsx
+++ b/src/app/admin/(protected)/settings/loading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function AdminSettingsLoading() {
+  return (
+    <div className="max-w-2xl mx-auto px-8 pt-6 pb-10">
+      <Skeleton className="h-4 w-16 mb-6" />
+      <div className="bg-white rounded-lg border border-gray-200 p-8 space-y-5">
+        <Skeleton className="h-7 w-44 mb-2" />
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i}>
+            <Skeleton className="h-4 w-28 mb-1" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        ))}
+        <Skeleton className="h-10 w-28 rounded" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import NextTopLoader from "nextjs-toploader";
 import { QueryClientProvider } from "@/shared/presentation/providers/QueryClientProvider";
 
 const geistSans = Geist({
@@ -27,6 +28,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {/* QueryClientProvider is 'use client' internally — wraps only what needs it */}
+        <NextTopLoader showSpinner={false} />
         <QueryClientProvider>
           {children}
         </QueryClientProvider>

--- a/src/shared/presentation/common/atoms/Skeleton.tsx
+++ b/src/shared/presentation/common/atoms/Skeleton.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  className?: string;
+}
+
+export function Skeleton({ className }: Props) {
+  return <div className={`animate-pulse rounded bg-zinc-200 ${className ?? ''}`} />;
+}


### PR DESCRIPTION
Closes #48

## Summary

- Add `nextjs-toploader` — progress bar that fires **immediately on click** (patches `history.pushState`), before any server response
- Add `Skeleton` atom (`animate-pulse` primitive)
- Add `loading.tsx` per route segment so Next.js shows skeletons while Server Components fetch data

## Root cause

Next.js `Link` uses `startTransition` internally — React holds the current page's UI until the server responds. The URL doesn't change and no loading state shows until the first server bytes arrive. On a cold Apps Script cache, that's several seconds of perceived freeze.

## What each commit does

| Commit | Change |
|---|---|
| `365ed76` | `Skeleton` atom + `loading.tsx` for all 6 affected routes |
| `97c29a2` | `nextjs-toploader` in root layout — instant progress bar on click |
| `5de6952` | Backlog index update |

## Navigation flow after this PR

1. **Click** → top progress bar appears instantly
2. **Server fetches** (cold Apps Script cache) → skeleton replaces old page
3. **Data ready** → real content renders

## Test plan

- [ ] Click a job on the career page — progress bar appears immediately, skeleton shows while data loads
- [ ] Click "Apply Now" on job detail — same instant feedback
- [ ] First-time load (cold cache) — no blank stare, skeleton appears
- [ ] Admin: navigate to Jobs, Settings — skeleton shows while data fetches
- [ ] `npm run build` passes clean
- [ ] `npm run test` — all 56 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)