### PR TITLE
feat(#50): UI revamp — Miro-inspired design system

### DIFF
--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -1,0 +1,1 @@
+../web-agentic/agents/issue-worker.md

--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -40,3 +40,4 @@ Tracked issues for **WeHire**. Source of truth is GitHub Issues — this file is
 | 044 | fix architecture violations: promote shared entities, fix cross-feature coupling, clean dead code | `pending` | [#44](https://github.com/handharr-labs/wehire/issues/44) |
 | 046 | fix all architecture violations and warnings from 2026-04-09 review | `pending` | [#46](https://github.com/handharr-labs/wehire/issues/46) |
 | 048 | feat: optimistic navigation + skeleton loading states across the project | `open` | [#48](https://github.com/handharr-labs/wehire/issues/48) |
+| 050 | UI revamp: Miro-inspired design system | `pending` | [#50](https://github.com/handharr-labs/wehire/issues/50) |

--- a/src/features/career-microsite/presentation/career-page/CareerPageView.tsx
+++ b/src/features/career-microsite/presentation/career-page/CareerPageView.tsx
@@ -12,17 +12,36 @@ export function CareerPageView({ initialData }: Props) {
 
   return (
     <main className="min-h-screen bg-[#FAFAFC]">
-      <header className="bg-[var(--brand-primary)] py-16">
-        <div className="max-w-3xl mx-auto px-4 flex flex-col items-center text-center">
-          {company.logoUrl && (
-            <div className="bg-white/15 rounded-2xl p-3 mb-5">
+      <header className="relative bg-[var(--brand-primary)] py-20 overflow-hidden">
+        {/* Dot grid texture for depth */}
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{ backgroundImage: 'radial-gradient(circle, white 1.5px, transparent 1.5px)', backgroundSize: '28px 28px' }}
+        />
+        {/* Bottom fade */}
+        <div className="absolute bottom-0 inset-x-0 h-16 bg-gradient-to-t from-black/10 to-transparent" />
+
+        <div className="relative max-w-3xl mx-auto px-4 flex flex-col items-center text-center">
+          {/* Logo or monogram fallback */}
+          {company.logoUrl ? (
+            <div className="bg-white rounded-2xl p-4 mb-6 shadow-lg">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={company.logoUrl} alt={company.name} className="h-12 w-auto object-contain" />
             </div>
+          ) : (
+            <div className="bg-white/20 rounded-2xl w-16 h-16 flex items-center justify-center mb-6 text-2xl font-bold text-[var(--brand-header-text)]">
+              {company.name.charAt(0)}
+            </div>
           )}
-          <h1 className="text-3xl font-bold text-[var(--brand-header-text)] tracking-tight">{company.name}</h1>
+
+          {/* "We're hiring" pill */}
+          <div className="bg-white/20 text-[var(--brand-header-text)] text-xs font-semibold px-3 py-1 rounded-full mb-4 uppercase tracking-widest">
+            We&apos;re hiring
+          </div>
+
+          <h1 className="text-4xl sm:text-5xl font-bold text-[var(--brand-header-text)] tracking-tight">{company.name}</h1>
           {company.description && (
-            <p className="mt-3 text-[var(--brand-header-text)] opacity-75 text-sm max-w-md leading-relaxed">{company.description}</p>
+            <p className="mt-4 text-[var(--brand-header-text)] text-sm max-w-md leading-relaxed [text-shadow:0_1px_3px_rgba(0,0,0,0.15)]">{company.description}</p>
           )}
         </div>
       </header>

--- a/src/features/career-microsite/presentation/career-page/CareerPageView.tsx
+++ b/src/features/career-microsite/presentation/career-page/CareerPageView.tsx
@@ -11,34 +11,57 @@ export function CareerPageView({ initialData }: Props) {
   const { company, jobs, isHiring } = buildCareerPageViewModel(initialData);
 
   return (
-    <main className="min-h-screen bg-zinc-50">
-      <header className="bg-[var(--brand-primary)] py-12">
-        <div className="max-w-3xl mx-auto px-4">
+    <main className="min-h-screen bg-[#FAFAFC]">
+      <header className="bg-[var(--brand-primary)] py-16">
+        <div className="max-w-3xl mx-auto px-4 flex flex-col items-center text-center">
           {company.logoUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={company.logoUrl} alt={company.name} className="h-12 object-contain mb-4" />
+            <div className="bg-white/15 rounded-2xl p-3 mb-5">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={company.logoUrl} alt={company.name} className="h-12 w-auto object-contain" />
+            </div>
           )}
-          <h1 className="text-2xl font-bold text-[var(--brand-header-text)]">{company.name}</h1>
+          <h1 className="text-3xl font-bold text-[var(--brand-header-text)] tracking-tight">{company.name}</h1>
           {company.description && (
-            <p className="mt-2 text-[var(--brand-header-text)] opacity-75 text-sm">{company.description}</p>
+            <p className="mt-3 text-[var(--brand-header-text)] opacity-75 text-sm max-w-md leading-relaxed">{company.description}</p>
           )}
         </div>
       </header>
 
-      <section className="max-w-3xl mx-auto px-4 py-10">
-        <h2 className="text-lg font-semibold text-zinc-800 mb-6">Open Positions</h2>
+      <section className="max-w-3xl mx-auto px-4 py-12">
+        <h2 className="text-xl font-bold text-[#1A1A2E] mb-6">
+          Open Positions
+          {isHiring && jobs.length > 0 && (
+            <span className="ml-2 text-sm font-medium text-[#5E5E7A]">({jobs.length})</span>
+          )}
+        </h2>
 
         {!isHiring ? (
-          <p className="text-zinc-500 text-sm">This company is not currently hiring.</p>
+          <div className="bg-white rounded-xl border border-[#E8E8F0] p-10 text-center">
+            <p className="text-[#5E5E7A] text-sm">This company is not currently hiring.</p>
+          </div>
         ) : jobs.length === 0 ? (
-          <p className="text-zinc-500 text-sm">No open positions at the moment.</p>
+          <div className="bg-white rounded-xl border border-[#E8E8F0] p-10 text-center">
+            <p className="text-[#5E5E7A] text-sm">No open positions at the moment. Check back soon.</p>
+          </div>
         ) : (
-          <ul className="space-y-4">
+          <ul className="space-y-3">
             {jobs.map((job) => (
-              <li key={job.id} className="bg-white rounded-lg border border-zinc-200 p-5 hover:border-[var(--brand-primary)] transition-colors">
-                <Link href={`/${company.slug}/jobs/${job.id}`} className="block">
-                  <h3 className="font-semibold text-zinc-900">{job.title}</h3>
-                  <p className="text-sm text-zinc-500 mt-1">{job.department} · {job.location} · {job.employmentType}</p>
+              <li key={job.id}>
+                <Link
+                  href={`/${company.slug}/jobs/${job.id}`}
+                  className="group flex items-center justify-between bg-white rounded-xl border border-[#E8E8F0] p-6 hover:border-[var(--brand-primary)] hover:shadow-md transition-all"
+                >
+                  <div>
+                    <h3 className="font-semibold text-[#1A1A2E] group-hover:text-[var(--brand-primary)] transition-colors">{job.title}</h3>
+                    <div className="flex flex-wrap gap-2 mt-2">
+                      <span className="bg-[#F5F5F8] text-[#5E5E7A] text-xs px-2.5 py-1 rounded-full">{job.department}</span>
+                      <span className="bg-[#F5F5F8] text-[#5E5E7A] text-xs px-2.5 py-1 rounded-full">{job.location}</span>
+                      <span className="bg-[#F5F5F8] text-[#5E5E7A] text-xs px-2.5 py-1 rounded-full capitalize">{job.employmentType}</span>
+                    </div>
+                  </div>
+                  <svg className="w-5 h-5 text-[#5E5E7A] group-hover:text-[var(--brand-primary)] shrink-0 ml-4 transition-colors" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+                  </svg>
                 </Link>
               </li>
             ))}

--- a/src/features/career-microsite/presentation/job-detail/JobDetailView.tsx
+++ b/src/features/career-microsite/presentation/job-detail/JobDetailView.tsx
@@ -11,45 +11,65 @@ export function JobDetailView({ initialData }: Props) {
   const { company, job, salaryLabel, isOpen } = buildJobDetailViewModel(initialData);
 
   return (
-    <main className="min-h-screen bg-zinc-50">
+    <main className="min-h-screen bg-[#FAFAFC]">
       <div className="max-w-3xl mx-auto px-4 py-10">
-        <Link href={`/${company.slug}`} className="text-sm text-zinc-500 hover:text-zinc-800 mb-6 block">
-          ← Back to {company.name}
+        <Link
+          href={`/${company.slug}`}
+          className="inline-flex items-center gap-1.5 text-sm text-[#5E5E7A] hover:text-[#1A1A2E] mb-8 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 18l-6-6 6-6" />
+          </svg>
+          {company.name}
         </Link>
 
-        <div className="bg-white rounded-lg border border-zinc-200 p-8">
-          <h1 className="text-2xl font-bold text-zinc-900">{job.title}</h1>
-          <p className="text-sm text-zinc-500 mt-1">
-            {job.department} · {job.location} · {job.employmentType}
-          </p>
-          <p className="text-sm font-medium text-zinc-700 mt-2">{salaryLabel}</p>
+        <div className="bg-white rounded-xl border border-[#E8E8F0] p-8 mb-6">
+          <h1 className="text-3xl font-bold text-[#1A1A2E] tracking-tight">{job.title}</h1>
 
-          <hr className="my-6 border-zinc-100" />
+          <div className="flex flex-wrap gap-2 mt-4">
+            <span className="bg-[#F5F5F8] text-[#5E5E7A] text-xs px-2.5 py-1 rounded-full">{job.department}</span>
+            <span className="bg-[#F5F5F8] text-[#5E5E7A] text-xs px-2.5 py-1 rounded-full">{job.location}</span>
+            <span className="bg-[#F5F5F8] text-[#5E5E7A] text-xs px-2.5 py-1 rounded-full capitalize">{job.employmentType}</span>
+            <span className="bg-[#EEF0FF] text-[#4262FF] text-xs px-2.5 py-1 rounded-full font-medium">{salaryLabel}</span>
+          </div>
+
+          <hr className="my-8 border-[#E8E8F0]" />
 
           <section>
-            <h2 className="font-semibold text-zinc-800 mb-3">Job Description</h2>
-            <p className="text-zinc-600 text-sm whitespace-pre-line">{job.description}</p>
+            <h2 className="font-semibold text-[#1A1A2E] text-lg mb-4">About the Role</h2>
+            <p className="text-[#5E5E7A] text-sm whitespace-pre-line leading-relaxed">{job.description}</p>
           </section>
 
-          <section className="mt-6">
-            <h2 className="font-semibold text-zinc-800 mb-3">Requirements</h2>
-            <p className="text-zinc-600 text-sm whitespace-pre-line">{job.requirements}</p>
+          <section className="mt-8">
+            <h2 className="font-semibold text-[#1A1A2E] text-lg mb-4">Requirements</h2>
+            <p className="text-[#5E5E7A] text-sm whitespace-pre-line leading-relaxed">{job.requirements}</p>
           </section>
 
-          <div className="mt-8">
+          <div className="mt-10">
             {isOpen ? (
               <Link
                 href={`/${company.slug}/jobs/${job.id}/apply`}
-                className="inline-block bg-[var(--brand-primary)] text-white px-6 py-3 rounded-lg text-sm font-medium hover:bg-[var(--brand-secondary)] transition-colors"
+                className="hidden md:inline-block bg-[var(--brand-primary)] text-white px-7 py-3.5 rounded-xl text-sm font-semibold hover:bg-[var(--brand-secondary)] transition-colors"
               >
                 Apply Now
               </Link>
             ) : (
-              <p className="text-sm text-zinc-500">This position is no longer accepting applications.</p>
+              <p className="text-sm text-[#5E5E7A]">This position is no longer accepting applications.</p>
             )}
           </div>
         </div>
       </div>
+
+      {isOpen && (
+        <div className="fixed bottom-0 inset-x-0 bg-white border-t border-[#E8E8F0] p-4 md:hidden">
+          <Link
+            href={`/${company.slug}/jobs/${job.id}/apply`}
+            className="block w-full bg-[var(--brand-primary)] text-white text-center py-3.5 rounded-xl text-sm font-semibold hover:bg-[var(--brand-secondary)] transition-colors"
+          >
+            Apply Now
+          </Link>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/features/marketing-landing/presentation/MarketingLandingView.tsx
+++ b/src/features/marketing-landing/presentation/MarketingLandingView.tsx
@@ -14,7 +14,7 @@ export function MarketingLandingView() {
         <BottomCtaSection />
       </main>
 
-      <footer className="text-zinc-400 text-sm text-center py-8">
+      <footer className="bg-white border-t border-[#E8E8F0] text-[#5E5E7A] text-sm text-center py-8">
         © 2025 WeHire · Handharr Labs
       </footer>
     </div>

--- a/src/features/marketing-landing/presentation/molecules/MarketingNavBar.tsx
+++ b/src/features/marketing-landing/presentation/molecules/MarketingNavBar.tsx
@@ -1,13 +1,23 @@
+import Link from 'next/link';
+
 export function MarketingNavBar() {
   return (
-    <nav className="flex items-center justify-between px-6 py-4 border-b border-zinc-100 bg-white">
-      <span className="font-bold text-zinc-900 text-lg">WeHire</span>
-      <a
-        href="#request-access"
-        className="text-sm font-semibold text-indigo-600 hover:text-indigo-700 transition-colors"
-      >
-        Get Started
-      </a>
+    <nav className="sticky top-0 z-40 flex items-center justify-between px-6 py-4 bg-white/80 backdrop-blur border-b border-[#E8E8F0]">
+      <span className="font-bold text-[#1A1A2E] text-lg tracking-tight">WeHire</span>
+      <div className="flex items-center gap-4">
+        <Link
+          href="/admin/login"
+          className="text-sm font-medium text-[#5E5E7A] hover:text-[#1A1A2E] transition-colors"
+        >
+          Login
+        </Link>
+        <a
+          href="#request-access"
+          className="text-sm font-semibold bg-[#4262FF] hover:bg-[#3651E6] text-white px-4 py-2 rounded-xl transition-colors"
+        >
+          Get Started
+        </a>
+      </div>
     </nav>
   );
 }

--- a/src/features/marketing-landing/presentation/organisms/BottomCtaSection.tsx
+++ b/src/features/marketing-landing/presentation/organisms/BottomCtaSection.tsx
@@ -1,17 +1,19 @@
 export function BottomCtaSection() {
   return (
-    <section id="request-access" className="bg-indigo-600 text-white py-20 px-4 text-center">
-      <div className="max-w-2xl mx-auto">
-        <h2 className="text-3xl font-bold mb-4">Ready to launch your career page?</h2>
-        <p className="text-indigo-100 mb-8">
-          Request early access — we&apos;ll set up your microsite and onboard you personally.
-        </p>
-        <a
-          href="mailto:hello@wehire.id"
-          className="inline-block bg-white text-indigo-600 rounded-lg px-6 py-3 font-semibold hover:bg-indigo-50 transition-colors"
-        >
-          Request Access
-        </a>
+    <section id="request-access" className="bg-[#FAFAFC] py-24 px-4">
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-gradient-to-br from-[#4262FF] to-[#6B4EFF] rounded-2xl px-10 py-16 text-center text-white">
+          <h2 className="text-3xl sm:text-4xl font-bold mb-4 tracking-tight">Ready to launch your career page?</h2>
+          <p className="text-white/75 mb-10 max-w-md mx-auto leading-relaxed">
+            Request early access — we&apos;ll set up your microsite and onboard you personally.
+          </p>
+          <a
+            href="mailto:hello@wehire.id"
+            className="inline-block bg-white text-[#4262FF] rounded-xl px-7 py-3.5 font-semibold hover:bg-[#F5F5FF] transition-colors"
+          >
+            Request Access
+          </a>
+        </div>
       </div>
     </section>
   );

--- a/src/features/marketing-landing/presentation/organisms/FeaturesSection.tsx
+++ b/src/features/marketing-landing/presentation/organisms/FeaturesSection.tsx
@@ -1,11 +1,9 @@
-'use client';
-
 const features = [
   {
     title: 'Your Own Branded Microsite',
     description: 'Publish a career page at wehire.id/your-company with your logo and colors.',
     icon: (
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <circle cx="12" cy="12" r="10" />
         <line x1="2" y1="12" x2="22" y2="12" />
         <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
@@ -16,9 +14,12 @@ const features = [
     title: 'Free to Start',
     description: 'Get your first career page live at no cost. Upgrade only when your team grows.',
     icon: (
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 3l1.5 4.5h4.5l-3.5 2.5 1.5 4.5L12 12l-4 2.5 1.5-4.5L6 7.5h4.5z" />
-        <path d="M5 20h14" />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="20 12 20 22 4 22 4 12" />
+        <rect x="2" y="7" width="20" height="5" />
+        <line x1="12" y1="22" x2="12" y2="7" />
+        <path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z" />
+        <path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z" />
       </svg>
     ),
   },
@@ -26,7 +27,7 @@ const features = [
     title: 'Up and Running in Minutes',
     description: 'Fill in your details, add open roles, and share your link. That\u2019s it.',
     icon: (
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
       </svg>
     ),
@@ -35,14 +36,23 @@ const features = [
 
 export function FeaturesSection() {
   return (
-    <section className="bg-white py-20 px-4">
+    <section id="features" className="bg-[#FAFAFC] py-24 px-4">
       <div className="max-w-5xl mx-auto">
+        <div className="text-center mb-14">
+          <h2 className="text-3xl font-bold text-[#1A1A2E] tracking-tight">Everything you need to start hiring</h2>
+          <p className="text-[#5E5E7A] mt-3 max-w-md mx-auto">No HR software, no design skills, no budget required.</p>
+        </div>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
           {features.map((feature) => (
-            <div key={feature.title} className="bg-white rounded-xl border border-zinc-200 p-6">
-              <div className="text-indigo-600 mb-4">{feature.icon}</div>
-              <h3 className="font-semibold text-zinc-900 mb-2">{feature.title}</h3>
-              <p className="text-sm text-zinc-500">{feature.description}</p>
+            <div
+              key={feature.title}
+              className="bg-white rounded-xl border border-[#E8E8F0] p-8 hover:shadow-md transition-shadow"
+            >
+              <div className="w-12 h-12 rounded-xl bg-[#EEF0FF] text-[#4262FF] flex items-center justify-center mb-5">
+                {feature.icon}
+              </div>
+              <h3 className="font-semibold text-[#1A1A2E] mb-2">{feature.title}</h3>
+              <p className="text-sm text-[#5E5E7A] leading-relaxed">{feature.description}</p>
             </div>
           ))}
         </div>

--- a/src/features/marketing-landing/presentation/organisms/HeroSection.tsx
+++ b/src/features/marketing-landing/presentation/organisms/HeroSection.tsx
@@ -1,19 +1,30 @@
 export function HeroSection() {
   return (
-    <section className="bg-gradient-to-b from-indigo-50 to-white">
-      <div className="max-w-2xl mx-auto px-4 py-24 text-center">
-        <h1 className="text-4xl font-bold text-zinc-900 mb-4 sm:text-5xl">
+    <section className="bg-gradient-to-b from-[#EEF0FF] to-[#FAFAFC]">
+      <div className="max-w-3xl mx-auto px-4 py-28 text-center">
+        <div className="inline-block bg-[#EEF0FF] text-[#4262FF] text-xs font-semibold px-3 py-1.5 rounded-full mb-6 tracking-wide uppercase">
+          No Credit Card Required
+        </div>
+        <h1 className="text-5xl sm:text-6xl font-bold text-[#1A1A2E] mb-6 leading-tight tracking-tight">
           Your brand. Your career page. In minutes.
         </h1>
-        <p className="text-lg text-zinc-500 mb-8">
+        <p className="text-lg text-[#5E5E7A] mb-10 max-w-xl mx-auto leading-relaxed">
           WeHire gives small businesses in Indonesia a branded recruitment microsite — shareable, and free to start.
         </p>
-        <a
-          href="#request-access"
-          className="inline-block bg-indigo-600 text-white rounded-lg px-6 py-3 font-semibold hover:bg-indigo-700 transition-colors"
-        >
-          Get Started
-        </a>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <a
+            href="#request-access"
+            className="inline-block bg-[#4262FF] hover:bg-[#3651E6] text-white rounded-xl px-7 py-3.5 font-semibold transition-colors"
+          >
+            Get Started Free
+          </a>
+          <a
+            href="#features"
+            className="inline-block bg-white border border-[#E8E8F0] text-[#1A1A2E] rounded-xl px-7 py-3.5 font-semibold hover:bg-[#FAFAFC] transition-colors"
+          >
+            See How It Works
+          </a>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
Closes #50

## Summary
- Revamps 3 public-facing screens with a Miro-inspired design system (clean, modern, confident)
- Applies consistent tokens: `#4262FF` primary, `#FAFAFC` background, `rounded-xl` radius, soft shadows
- All 56 tests pass, 0 lint errors

## Changes

**Marketing Landing (`/`)**
- Sticky frosted navbar with Login link + solid Get Started button
- Hero: badge pill, dual CTAs, violet gradient background
- Feature cards: icon tiles in brand-tinted squares, hover shadows
- Bottom CTA: gradient banner with rounded card layout

**Career Microsite (`/[slug]`)**
- Header: dot grid texture, bottom fade, monogram fallback when no logo, "We're hiring" pill, larger headline
- Job cards: meta chips for department/location/type, chevron affordance, hover border + shadow

**Job Detail (`/[slug]/jobs/[jobId]`)**
- Badge row with salary chip in brand tint
- "About the Role" section heading, relaxed typography
- Mobile sticky bottom Apply button bar

## Test plan
- [ ] `npm run test` — all 56 tests pass
- [ ] Visit `/` — marketing landing with new design
- [ ] Visit `/kreasi-digital` — career page with textured header and monogram
- [ ] Visit a job detail — badge row, salary chip, mobile sticky Apply bar
- [ ] Test with a company that has a custom brand color — theming still respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)