### PR TITLE
feat(form-fields): admin-configurable form fields with dynamic sheet sync

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -18,11 +18,12 @@ function doGet(e) {
   try {
     var action = e.parameter.action;
 
-    if (action === 'getCompanies') return handleGetCompanies(e);
-    if (action === 'getCompany') return handleGetCompany(e);
-    if (action === 'getJobs')      return handleGetJobs(e);
-    if (action === 'getJob')       return handleGetJob(e);
-    if (action === 'getJobBySlug') return handleGetJobBySlug(e);
+    if (action === 'getCompanies')  return handleGetCompanies(e);
+    if (action === 'getCompany')    return handleGetCompany(e);
+    if (action === 'getJobs')       return handleGetJobs(e);
+    if (action === 'getJob')        return handleGetJob(e);
+    if (action === 'getJobBySlug')  return handleGetJobBySlug(e);
+    if (action === 'getFormFields') return handleGetFormFields(e);
 
     return jsonResponse({ error: 'Unknown action: ' + action }, 400);
   } catch (err) {
@@ -35,11 +36,15 @@ function doPost(e) {
   try {
     if (e.postData && e.postData.type === 'application/json') {
       var body = JSON.parse(e.postData.contents);
-      if (body.action === 'getAdminByEmail') return handleGetAdminByEmail(body);
-      if (body.action === 'createJob')       return handleCreateJob(body);
-      if (body.action === 'updateJob')       return handleUpdateJob(body);
-      if (body.action === 'deleteJob')       return handleDeleteJob(body);
-      if (body.action === 'updateCompany')   return handleUpdateCompany(body);
+      if (body.action === 'getAdminByEmail')    return handleGetAdminByEmail(body);
+      if (body.action === 'createJob')          return handleCreateJob(body);
+      if (body.action === 'updateJob')          return handleUpdateJob(body);
+      if (body.action === 'deleteJob')          return handleDeleteJob(body);
+      if (body.action === 'updateCompany')      return handleUpdateCompany(body);
+      if (body.action === 'createFormField')    return handleCreateFormField(body);
+      if (body.action === 'updateFormField')    return handleUpdateFormField(body);
+      if (body.action === 'deleteFormField')    return handleDeleteFormField(body);
+      if (body.action === 'reorderFormFields')  return handleReorderFormFields(body);
       return jsonResponse({ error: 'Unknown action: ' + body.action }, 400);
     }
     return handleSubmitApplication(e);
@@ -374,6 +379,302 @@ function handleUpdateCompany(body) {
 }
 
 // ------------------------------------------------------------
+// Form Fields — default seed data
+// ------------------------------------------------------------
+
+var DEFAULT_FORM_FIELDS = [
+  { id: 'sys_1',  label: 'Full Name',           field_name: 'full_name',          type: 'text',     required: true,  options: '', sort_order: 1,  enabled: true, is_system: true },
+  { id: 'sys_2',  label: 'Email',               field_name: 'email',              type: 'email',    required: true,  options: '', sort_order: 2,  enabled: true, is_system: true },
+  { id: 'sys_3',  label: 'Phone',               field_name: 'phone',              type: 'tel',      required: true,  options: '', sort_order: 3,  enabled: true, is_system: true },
+  { id: 'sys_4',  label: 'City',                field_name: 'city',               type: 'text',     required: true,  options: '', sort_order: 4,  enabled: true, is_system: true },
+  { id: 'sys_5',  label: 'Experience Summary',  field_name: 'experience_summary', type: 'textarea', required: true,  options: '', sort_order: 5,  enabled: true, is_system: true },
+  { id: 'sys_6',  label: 'Expected Salary',     field_name: 'expected_salary',    type: 'number',   required: true,  options: '', sort_order: 6,  enabled: true, is_system: true },
+  { id: 'sys_7',  label: 'CV / Resume',         field_name: 'cv_url',             type: 'file',     required: true,  options: '', sort_order: 7,  enabled: true, is_system: true },
+  { id: 'sys_8',  label: 'LinkedIn URL',        field_name: 'linkedin_url',       type: 'url',      required: false, options: '', sort_order: 8,  enabled: true, is_system: true },
+  { id: 'sys_9',  label: 'Portfolio URL',       field_name: 'portfolio_url',      type: 'url',      required: false, options: '', sort_order: 9,  enabled: true, is_system: true },
+  { id: 'sys_10', label: 'Cover Letter',        field_name: 'cover_letter',       type: 'textarea', required: false, options: '', sort_order: 10, enabled: true, is_system: true }
+];
+
+/**
+ * Returns the Form_Fields sheet for the given spreadsheet,
+ * creating and seeding it if it does not yet exist.
+ */
+function initFormFields(ss) {
+  var sheet = ss.getSheetByName('Form_Fields');
+  if (sheet) return sheet;
+
+  sheet = ss.insertSheet('Form_Fields');
+  sheet.appendRow(['id', 'label', 'field_name', 'type', 'required', 'options', 'sort_order', 'enabled', 'is_system']);
+  for (var i = 0; i < DEFAULT_FORM_FIELDS.length; i++) {
+    var f = DEFAULT_FORM_FIELDS[i];
+    sheet.appendRow([f.id, f.label, f.field_name, f.type, f.required, f.options, f.sort_order, f.enabled, f.is_system]);
+  }
+  return sheet;
+}
+
+/** Converts a label to a snake_case field_name. */
+function slugify(label) {
+  return String(label)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function toFormFieldDTO(row) {
+  return {
+    id:         String(row.id         || ''),
+    label:      String(row.label      || ''),
+    field_name: String(row.field_name || ''),
+    type:       String(row.type       || 'text'),
+    required:   row.required  === true || String(row.required).toLowerCase()  === 'true',
+    options:    String(row.options    || ''),
+    sort_order: Number(row.sort_order || 0),
+    enabled:    row.enabled   === true || String(row.enabled).toLowerCase()   === 'true',
+    is_system:  row.is_system === true || String(row.is_system).toLowerCase() === 'true'
+  };
+}
+
+// ------------------------------------------------------------
+// Form Fields — GET handler
+// ------------------------------------------------------------
+
+function handleGetFormFields(e) {
+  var companyId = e.parameter.companyId;
+  if (!companyId) return jsonResponse({ error: 'Missing parameter: companyId' }, 400);
+
+  var company = findCompanyById(companyId);
+  if (!company) return jsonResponse({ error: 'Company not found: ' + companyId }, 404);
+
+  var ss    = openCompanySpreadsheet(company.slug);
+  var sheet = initFormFields(ss);
+  var rows  = sheet.getDataRange().getValues();
+  var headers = rows[0];
+  var fields  = [];
+
+  for (var i = 1; i < rows.length; i++) {
+    fields.push(toFormFieldDTO(rowToObject(headers, rows[i])));
+  }
+
+  return jsonResponse({ data: fields });
+}
+
+// ------------------------------------------------------------
+// Form Fields — POST handlers (admin, require secret)
+// ------------------------------------------------------------
+
+function handleCreateFormField(body) {
+  if (!validateAdminSecret(body.secret)) return jsonResponse({ error: 'Forbidden' }, 403);
+
+  var companyId = body.companyId;
+  if (!companyId)  return jsonResponse({ error: 'Missing parameter: companyId' }, 400);
+  if (!body.label) return jsonResponse({ error: 'Missing parameter: label' }, 400);
+  if (!body.type)  return jsonResponse({ error: 'Missing parameter: type' }, 400);
+
+  var company = findCompanyById(companyId);
+  if (!company) return jsonResponse({ error: 'Company not found: ' + companyId }, 404);
+
+  var ss    = openCompanySpreadsheet(company.slug);
+  var sheet = initFormFields(ss);
+
+  var fieldName = slugify(body.label);
+
+  // Ensure field_name is unique among enabled fields
+  var rows    = sheet.getDataRange().getValues();
+  var headers = rows[0];
+  var existing = [];
+  for (var i = 1; i < rows.length; i++) {
+    var r = rowToObject(headers, rows[i]);
+    if (r.enabled !== false && String(r.enabled).toLowerCase() !== 'false') {
+      existing.push(String(r.field_name));
+    }
+  }
+  if (existing.indexOf(fieldName) !== -1) {
+    fieldName = fieldName + '_' + Date.now();
+  }
+
+  // Max sort_order
+  var maxOrder = 0;
+  for (var j = 1; j < rows.length; j++) {
+    var o = Number(rows[j][6]);
+    if (o > maxOrder) maxOrder = o;
+  }
+
+  var newId     = 'cf_' + Date.now();
+  var sortOrder = body.sort_order != null ? Number(body.sort_order) : maxOrder + 1;
+  var required  = body.required === true || body.required === 'true';
+  var options   = body.options || '';
+
+  sheet.appendRow([newId, body.label, fieldName, body.type, required, options, sortOrder, true, false]);
+
+  // Add column to Candidates sheet
+  var candidatesSheet = ss.getSheetByName('Candidates');
+  if (candidatesSheet) ensureColumn(candidatesSheet, fieldName);
+
+  return jsonResponse({ data: { id: newId, field_name: fieldName } });
+}
+
+function handleUpdateFormField(body) {
+  if (!validateAdminSecret(body.secret)) return jsonResponse({ error: 'Forbidden' }, 403);
+
+  var companyId = body.companyId;
+  var fieldId   = body.fieldId;
+  if (!companyId) return jsonResponse({ error: 'Missing parameter: companyId' }, 400);
+  if (!fieldId)   return jsonResponse({ error: 'Missing parameter: fieldId' }, 400);
+
+  var company = findCompanyById(companyId);
+  if (!company) return jsonResponse({ error: 'Company not found: ' + companyId }, 404);
+
+  var ss    = openCompanySpreadsheet(company.slug);
+  var sheet = initFormFields(ss);
+
+  var rows    = sheet.getDataRange().getValues();
+  var headers = rows[0];
+  var colMap  = {};
+  for (var c = 0; c < headers.length; c++) colMap[headers[c]] = c + 1;
+
+  for (var i = 1; i < rows.length; i++) {
+    var row = rowToObject(headers, rows[i]);
+    if (String(row.id) !== String(fieldId)) continue;
+
+    var sheetRow = i + 1;
+    var isSystem = row.is_system === true || String(row.is_system).toLowerCase() === 'true';
+
+    // Label change
+    if (body.label !== undefined && body.label !== row.label) {
+      sheet.getRange(sheetRow, colMap['label']).setValue(body.label);
+
+      // For custom fields: derive new field_name and rename Candidates column
+      if (!isSystem) {
+        var oldFieldName = String(row.field_name);
+        var newFieldName = slugify(body.label);
+        if (newFieldName !== oldFieldName) {
+          sheet.getRange(sheetRow, colMap['field_name']).setValue(newFieldName);
+
+          var candidatesSheet = ss.getSheetByName('Candidates');
+          if (candidatesSheet) {
+            var lastCol = candidatesSheet.getLastColumn();
+            if (lastCol > 0) {
+              var cHeaders = candidatesSheet.getRange(1, 1, 1, lastCol).getValues()[0];
+              var colIdx   = cHeaders.indexOf(oldFieldName);
+              if (colIdx !== -1) {
+                candidatesSheet.getRange(1, colIdx + 1).setValue(newFieldName);
+              } else {
+                // Column didn't exist yet — create it under the new name
+                ensureColumn(candidatesSheet, newFieldName);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (body.required !== undefined) {
+      sheet.getRange(sheetRow, colMap['required']).setValue(
+        body.required === true || body.required === 'true'
+      );
+    }
+    if (body.options !== undefined) {
+      sheet.getRange(sheetRow, colMap['options']).setValue(body.options);
+    }
+    if (body.enabled !== undefined) {
+      // Core system fields (sort_order <= 7) cannot be disabled
+      var sortOrder = Number(row.sort_order);
+      if (isSystem && sortOrder <= 7) {
+        return jsonResponse({ error: 'Cannot disable core system fields' }, 400);
+      }
+      sheet.getRange(sheetRow, colMap['enabled']).setValue(
+        body.enabled === true || body.enabled === 'true'
+      );
+    }
+
+    return jsonResponse({ success: true });
+  }
+
+  return jsonResponse({ error: 'Field not found: ' + fieldId }, 404);
+}
+
+function handleDeleteFormField(body) {
+  if (!validateAdminSecret(body.secret)) return jsonResponse({ error: 'Forbidden' }, 403);
+
+  var companyId = body.companyId;
+  var fieldId   = body.fieldId;
+  if (!companyId) return jsonResponse({ error: 'Missing parameter: companyId' }, 400);
+  if (!fieldId)   return jsonResponse({ error: 'Missing parameter: fieldId' }, 400);
+
+  var company = findCompanyById(companyId);
+  if (!company) return jsonResponse({ error: 'Company not found: ' + companyId }, 404);
+
+  var ss    = openCompanySpreadsheet(company.slug);
+  var sheet = initFormFields(ss);
+
+  var rows    = sheet.getDataRange().getValues();
+  var headers = rows[0];
+  var colMap  = {};
+  for (var c = 0; c < headers.length; c++) colMap[headers[c]] = c + 1;
+
+  for (var i = 1; i < rows.length; i++) {
+    var row = rowToObject(headers, rows[i]);
+    if (String(row.id) !== String(fieldId)) continue;
+
+    var isSystem = row.is_system === true || String(row.is_system).toLowerCase() === 'true';
+    if (isSystem) return jsonResponse({ error: 'Cannot delete system fields' }, 400);
+
+    // Soft delete — mark the Candidates column header and disable the field
+    var fieldName = String(row.field_name);
+    var candidatesSheet = ss.getSheetByName('Candidates');
+    if (candidatesSheet) {
+      var lastCol = candidatesSheet.getLastColumn();
+      if (lastCol > 0) {
+        var cHeaders = candidatesSheet.getRange(1, 1, 1, lastCol).getValues()[0];
+        var colIdx   = cHeaders.indexOf(fieldName);
+        if (colIdx !== -1) {
+          candidatesSheet.getRange(1, colIdx + 1).setValue('[deleted]_' + fieldName);
+        }
+      }
+    }
+    sheet.getRange(i + 1, colMap['enabled']).setValue(false);
+    return jsonResponse({ success: true });
+  }
+
+  return jsonResponse({ error: 'Field not found: ' + fieldId }, 404);
+}
+
+function handleReorderFormFields(body) {
+  if (!validateAdminSecret(body.secret)) return jsonResponse({ error: 'Forbidden' }, 403);
+
+  var companyId = body.companyId;
+  var order     = body.order;
+  if (!companyId)             return jsonResponse({ error: 'Missing parameter: companyId' }, 400);
+  if (!order || !Array.isArray(order)) return jsonResponse({ error: 'Missing parameter: order' }, 400);
+
+  var company = findCompanyById(companyId);
+  if (!company) return jsonResponse({ error: 'Company not found: ' + companyId }, 404);
+
+  var ss    = openCompanySpreadsheet(company.slug);
+  var sheet = initFormFields(ss);
+
+  var rows    = sheet.getDataRange().getValues();
+  var headers = rows[0];
+  var colMap  = {};
+  for (var c = 0; c < headers.length; c++) colMap[headers[c]] = c + 1;
+
+  var orderMap = {};
+  for (var k = 0; k < order.length; k++) {
+    orderMap[String(order[k].id)] = Number(order[k].sort_order);
+  }
+
+  for (var i = 1; i < rows.length; i++) {
+    var id = String(rows[i][0]);
+    if (orderMap.hasOwnProperty(id)) {
+      sheet.getRange(i + 1, colMap['sort_order']).setValue(orderMap[id]);
+    }
+  }
+
+  return jsonResponse({ success: true });
+}
+
+// ------------------------------------------------------------
 // POST handler — multipart/form-data application submission
 // ------------------------------------------------------------
 
@@ -415,6 +716,24 @@ function handleSubmitApplication(e) {
   var companyResources = openCompanyResources(company.slug);
   var companySS        = companyResources.spreadsheet;
 
+  // Validate required custom fields
+  var formFieldsSheet = initFormFields(companySS);
+  var ffRows    = formFieldsSheet.getDataRange().getValues();
+  var ffHeaders = ffRows[0];
+  var missingCustom = [];
+  for (var fi = 1; fi < ffRows.length; fi++) {
+    var ff        = rowToObject(ffHeaders, ffRows[fi]);
+    var ffEnabled = ff.enabled  === true || String(ff.enabled).toLowerCase()  === 'true';
+    var ffReq     = ff.required === true || String(ff.required).toLowerCase() === 'true';
+    var ffSystem  = ff.is_system === true || String(ff.is_system).toLowerCase() === 'true';
+    if (!ffSystem && ffEnabled && ffReq && !field(String(ff.field_name))) {
+      missingCustom.push(String(ff.label));
+    }
+  }
+  if (missingCustom.length) {
+    return jsonResponse({ error: 'Missing required fields: ' + missingCustom.join(', ') }, 400);
+  }
+
   // CV upload
   var cvUrl = '';
   try {
@@ -449,7 +768,7 @@ function handleSubmitApplication(e) {
   var sheet = companySS.getSheetByName('Candidates');
   ensureColumn(sheet, 'screening_score');
 
-  appendRowByColumnMap(sheet, {
+  var rowData = {
     timestamp:          new Date().toISOString(),
     job_id:             jobId,
     company_id:         companyId,
@@ -464,7 +783,20 @@ function handleSubmitApplication(e) {
     portfolio_url:      portfolioUrl,
     cover_letter:       coverLetter,
     screening_score:    screeningScore !== '' ? Number(screeningScore) : ''
-  });
+  };
+
+  // Append enabled custom field values
+  for (var ci = 1; ci < ffRows.length; ci++) {
+    var cf       = rowToObject(ffHeaders, ffRows[ci]);
+    var cfEnabled = cf.enabled  === true || String(cf.enabled).toLowerCase()  === 'true';
+    var cfSystem  = cf.is_system === true || String(cf.is_system).toLowerCase() === 'true';
+    if (!cfSystem && cfEnabled) {
+      var cfName = String(cf.field_name);
+      rowData[cfName] = field(cfName) || '';
+    }
+  }
+
+  appendRowByColumnMap(sheet, rowData);
 
   return jsonResponse({ success: true });
 }

--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -41,3 +41,4 @@ Tracked issues for **WeHire**. Source of truth is GitHub Issues — this file is
 | 046 | fix all architecture violations and warnings from 2026-04-09 review | `done` | [#46](https://github.com/handharr-labs/wehire/issues/46) |
 | 048 | feat: optimistic navigation + skeleton loading states across the project | `done` | [#48](https://github.com/handharr-labs/wehire/issues/48) |
 | 050 | UI revamp: Miro-inspired design system | `done` | [#50](https://github.com/handharr-labs/wehire/issues/50) |
+| 053 | Add admin-configurable form fields with dynamic Google Sheet column sync | `pending` | [#53](https://github.com/handharr-labs/wehire/issues/53) |

--- a/src/app/[slug]/jobs/[jobId]/apply/ApplyFormClientWrapper.tsx
+++ b/src/app/[slug]/jobs/[jobId]/apply/ApplyFormClientWrapper.tsx
@@ -4,22 +4,25 @@ import { useRouter } from 'next/navigation';
 import { submitApplicationUseCase } from '@/di/container.client';
 import { type Company } from '@/shared/domain/entities/Company';
 import { type Job } from '@/shared/domain/entities/Job';
+import { type FormField } from '@/shared/domain/entities/FormField';
 import { ApplyFormView } from '@/features/career-microsite/presentation/apply-form/ApplyFormView';
 import { useApplyFormViewModel } from '@/features/career-microsite/presentation/apply-form/useApplyFormViewModel';
 
 interface Props {
   company: Company;
   job: Job;
+  formFields: FormField[];
 }
 
-export function ApplyFormClientWrapper({ company, job }: Props) {
+export function ApplyFormClientWrapper({ company, job, formFields }: Props) {
   const router = useRouter();
   const vm = useApplyFormViewModel(
     company,
     job,
     submitApplicationUseCase,
     () => router.push(`/${company.slug}/jobs/${job.id}/apply/success`),
+    formFields,
   );
 
-  return <ApplyFormView company={company} job={job} vm={vm} />;
+  return <ApplyFormView company={company} job={job} formFields={formFields} vm={vm} />;
 }

--- a/src/app/[slug]/jobs/[jobId]/apply/page.tsx
+++ b/src/app/[slug]/jobs/[jobId]/apply/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from 'next/navigation';
 import { getCachedCompanyBySlug, getCachedJobDetailBySlug } from '@/di/cachedQueries';
+import { getFormFieldsUseCase } from '@/di/container.server';
 import { ApplyFormClientWrapper } from './ApplyFormClientWrapper';
 import { BrandThemeStyle } from '@/shared/presentation/common/atoms/BrandThemeStyle';
 import { isJobOpen } from '@/features/career-microsite/domain/helpers/isJobOpen';
@@ -27,10 +28,18 @@ export default async function ApplyPage({ params }: Props) {
   if (company.siteStatus !== 'active') redirect(`/${slug}`);
   if (!isJobOpen(job, new Date())) redirect(`/${slug}/jobs/${jobId}`);
 
+  // Fetch enabled form fields; fall back to empty array so the page still renders
+  // with a degraded form if the Form_Fields sheet hasn't been seeded yet.
+  let formFields = await getFormFieldsUseCase.execute(company.id).catch(() => []);
+  // If no fields returned yet (brand new company), use an empty list — the
+  // ApplyFormView will show nothing until the admin configures fields, which is
+  // fine for MVP (the sheet will be seeded on first admin visit).
+  formFields = formFields.filter((f) => f.enabled).sort((a, b) => a.sortOrder - b.sortOrder);
+
   return (
     <>
       <BrandThemeStyle primaryColor={company.primaryColor} secondaryColor={company.secondaryColor} />
-      <ApplyFormClientWrapper company={company} job={job} />
+      <ApplyFormClientWrapper company={company} job={job} formFields={formFields} />
     </>
   );
 }

--- a/src/app/admin/(protected)/form-fields/loading.tsx
+++ b/src/app/admin/(protected)/form-fields/loading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from '@/shared/presentation/common/atoms/Skeleton';
+
+export default function AdminFormFieldsLoading() {
+  return (
+    <div className="max-w-2xl mx-auto px-8 pt-6 pb-10">
+      <Skeleton className="h-4 w-16 mb-6" />
+      <div className="bg-white rounded-lg border border-gray-200 p-8">
+        <Skeleton className="h-7 w-56 mb-2" />
+        <Skeleton className="h-4 w-72 mb-6" />
+        <div className="space-y-2">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
+        </div>
+        <Skeleton className="h-12 w-full rounded-lg mt-2" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/form-fields/page.tsx
+++ b/src/app/admin/(protected)/form-fields/page.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { notFound, redirect } from 'next/navigation';
+import { getAdminSession } from '@/lib/session';
+import { getFormFieldsUseCase } from '@/di/container.server';
+import { FormFieldsManagerView } from '@/features/admin-form-fields/presentation/views/FormFieldsManagerView';
+
+interface Props {
+  searchParams: Promise<{ companyId?: string }>;
+}
+
+export default async function AdminFormFieldsPage({ searchParams }: Props) {
+  const cookieStore = await cookies();
+  const session = await getAdminSession(cookieStore);
+
+  if (!session) {
+    redirect('/admin/login');
+  }
+
+  const resolvedParams = await searchParams;
+
+  if (session.role === 'SUPER_ADMIN' && !resolvedParams.companyId) {
+    redirect('/admin/dashboard');
+  }
+
+  const companyId =
+    session.role === 'SUPER_ADMIN' ? resolvedParams.companyId : (session.companyId ?? undefined);
+
+  if (!companyId) {
+    notFound();
+  }
+
+  const formFields = await getFormFieldsUseCase.execute(companyId);
+
+  return (
+    <>
+      <div className="max-w-2xl mx-auto px-8 pt-6">
+        <Link href="/admin/dashboard" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Back
+        </Link>
+      </div>
+      <FormFieldsManagerView initialFields={formFields} companyId={companyId} />
+    </>
+  );
+}

--- a/src/di/container.server.ts
+++ b/src/di/container.server.ts
@@ -31,6 +31,14 @@ import { CreateJobUseCaseImpl } from '@/features/admin-jobs/domain/use-cases/Cre
 import { UpdateJobUseCaseImpl } from '@/features/admin-jobs/domain/use-cases/UpdateJobUseCase';
 import { DeleteJobUseCaseImpl } from '@/features/admin-jobs/domain/use-cases/DeleteJobUseCase';
 import { VerifyCompanyConnectionUseCaseImpl } from '@/shared/domain/use-cases/VerifyCompanyConnectionUseCase';
+import { FormFieldRemoteDataSourceImpl } from '@/features/admin-form-fields/data/data-sources/FormFieldRemoteDataSource';
+import { FormFieldMapperImpl } from '@/features/admin-form-fields/data/mappers/FormFieldMapper';
+import { FormFieldRepositoryImpl } from '@/features/admin-form-fields/data/repositories/FormFieldRepositoryImpl';
+import { GetFormFieldsUseCaseImpl } from '@/features/admin-form-fields/domain/use-cases/GetFormFieldsUseCase';
+import { CreateFormFieldUseCaseImpl } from '@/features/admin-form-fields/domain/use-cases/CreateFormFieldUseCase';
+import { UpdateFormFieldUseCaseImpl } from '@/features/admin-form-fields/domain/use-cases/UpdateFormFieldUseCase';
+import { DeleteFormFieldUseCaseImpl } from '@/features/admin-form-fields/domain/use-cases/DeleteFormFieldUseCase';
+import { ReorderFormFieldsUseCaseImpl } from '@/features/admin-form-fields/domain/use-cases/ReorderFormFieldsUseCase';
 
 // Infrastructure — Node.js module cache provides free singletons.
 const httpClient = new AxiosHTTPClient(
@@ -95,3 +103,20 @@ export const deleteJobUseCase = new DeleteJobUseCaseImpl(jobManagementRepository
 export const verifyCompanyConnectionUseCase = new VerifyCompanyConnectionUseCaseImpl(
   companyRepository,
 );
+
+// Form fields
+const formFieldDataSource = new FormFieldRemoteDataSourceImpl(
+  httpClient,
+  process.env.ADMIN_API_SECRET ?? '',
+);
+const formFieldMapper = new FormFieldMapperImpl();
+const formFieldRepository = new FormFieldRepositoryImpl(
+  formFieldDataSource,
+  formFieldMapper,
+  errorMapper,
+);
+export const getFormFieldsUseCase = new GetFormFieldsUseCaseImpl(formFieldRepository);
+export const createFormFieldUseCase = new CreateFormFieldUseCaseImpl(formFieldRepository);
+export const updateFormFieldUseCase = new UpdateFormFieldUseCaseImpl(formFieldRepository);
+export const deleteFormFieldUseCase = new DeleteFormFieldUseCaseImpl(formFieldRepository);
+export const reorderFormFieldsUseCase = new ReorderFormFieldsUseCaseImpl(formFieldRepository);

--- a/src/features/admin-auth/presentation/login/LoginFormView.tsx
+++ b/src/features/admin-auth/presentation/login/LoginFormView.tsx
@@ -57,7 +57,7 @@ export function LoginFormView({ vm }: Props) {
           <button
             type="submit"
             disabled={vm.isPending}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded px-4 py-2 transition-colors"
+            className="w-full cursor-pointer bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded px-4 py-2 transition-colors"
           >
             {vm.isPending ? 'Signing in…' : 'Sign in'}
           </button>

--- a/src/features/admin-form-fields/data/data-sources/FormFieldRemoteDataSource.ts
+++ b/src/features/admin-form-fields/data/data-sources/FormFieldRemoteDataSource.ts
@@ -1,0 +1,84 @@
+import { type HTTPClient } from '@/data/networking/HTTPClient';
+import { type FormFieldDTO } from '@/shared/data/dtos/FormFieldDTO';
+import {
+  type CreateFormFieldDTO,
+  type UpdateFormFieldDTO,
+  type ReorderFormFieldsDTO,
+  type FormFieldWriteResultDTO,
+} from '../dtos/FormFieldWriteDTO';
+
+interface FormFieldsResponse {
+  data: FormFieldDTO[];
+}
+
+interface FormFieldCreateResponse {
+  data: FormFieldWriteResultDTO;
+}
+
+export interface FormFieldRemoteDataSource {
+  getFormFields(companyId: string): Promise<FormFieldDTO[]>;
+  createFormField(dto: CreateFormFieldDTO): Promise<FormFieldWriteResultDTO>;
+  updateFormField(companyId: string, fieldId: string, dto: UpdateFormFieldDTO): Promise<void>;
+  deleteFormField(companyId: string, fieldId: string): Promise<void>;
+  reorderFormFields(dto: ReorderFormFieldsDTO): Promise<void>;
+}
+
+export class FormFieldRemoteDataSourceImpl implements FormFieldRemoteDataSource {
+  constructor(
+    private readonly httpClient: HTTPClient,
+    private readonly adminSecret: string,
+  ) {}
+
+  async getFormFields(companyId: string): Promise<FormFieldDTO[]> {
+    const response = await this.httpClient.get<FormFieldsResponse>('', {
+      params: { action: 'getFormFields', companyId },
+    });
+    return response.data;
+  }
+
+  async createFormField(dto: CreateFormFieldDTO): Promise<FormFieldWriteResultDTO> {
+    const response = await this.httpClient.post<FormFieldCreateResponse>('', {
+      action: 'createFormField',
+      secret: this.adminSecret,
+      companyId: dto.companyId,
+      label: dto.label,
+      type: dto.type,
+      required: dto.required,
+      options: dto.options ?? '',
+      sort_order: dto.sort_order,
+    });
+    return response.data;
+  }
+
+  async updateFormField(
+    companyId: string,
+    fieldId: string,
+    dto: UpdateFormFieldDTO,
+  ): Promise<void> {
+    await this.httpClient.post('', {
+      action: 'updateFormField',
+      secret: this.adminSecret,
+      companyId,
+      fieldId,
+      ...dto,
+    });
+  }
+
+  async deleteFormField(companyId: string, fieldId: string): Promise<void> {
+    await this.httpClient.post('', {
+      action: 'deleteFormField',
+      secret: this.adminSecret,
+      companyId,
+      fieldId,
+    });
+  }
+
+  async reorderFormFields(dto: ReorderFormFieldsDTO): Promise<void> {
+    await this.httpClient.post('', {
+      action: 'reorderFormFields',
+      secret: this.adminSecret,
+      companyId: dto.companyId,
+      order: dto.order,
+    });
+  }
+}

--- a/src/features/admin-form-fields/data/dtos/FormFieldWriteDTO.ts
+++ b/src/features/admin-form-fields/data/dtos/FormFieldWriteDTO.ts
@@ -1,0 +1,26 @@
+export interface CreateFormFieldDTO {
+  companyId: string;
+  label: string;
+  type: string;
+  required: boolean;
+  options?: string;
+  sort_order?: number;
+}
+
+export interface UpdateFormFieldDTO {
+  label?: string;
+  type?: string;
+  required?: boolean;
+  options?: string;
+  enabled?: boolean;
+}
+
+export interface ReorderFormFieldsDTO {
+  companyId: string;
+  order: Array<{ id: string; sort_order: number }>;
+}
+
+export interface FormFieldWriteResultDTO {
+  id: string;
+  field_name: string;
+}

--- a/src/features/admin-form-fields/data/mappers/FormFieldMapper.ts
+++ b/src/features/admin-form-fields/data/mappers/FormFieldMapper.ts
@@ -1,0 +1,31 @@
+import { type FormField, type FormFieldType } from '@/shared/domain/entities/FormField';
+import { type FormFieldDTO } from '@/shared/data/dtos/FormFieldDTO';
+
+function toBool(value: boolean | string): boolean {
+  return value === true || String(value).toLowerCase() === 'true';
+}
+
+export interface FormFieldMapper {
+  toDomain(dto: FormFieldDTO): FormField;
+}
+
+export class FormFieldMapperImpl implements FormFieldMapper {
+  toDomain(dto: FormFieldDTO): FormField {
+    return {
+      id: String(dto.id ?? ''),
+      label: String(dto.label ?? ''),
+      fieldName: String(dto.field_name ?? ''),
+      type: (dto.type as FormFieldType) ?? 'text',
+      required: toBool(dto.required),
+      options: dto.options
+        ? String(dto.options)
+            .split(',')
+            .map((o) => o.trim())
+            .filter(Boolean)
+        : [],
+      sortOrder: Number(dto.sort_order ?? 0),
+      enabled: toBool(dto.enabled),
+      isSystem: toBool(dto.is_system),
+    };
+  }
+}

--- a/src/features/admin-form-fields/data/repositories/FormFieldRepositoryImpl.ts
+++ b/src/features/admin-form-fields/data/repositories/FormFieldRepositoryImpl.ts
@@ -1,0 +1,77 @@
+import { type FormField } from '@/shared/domain/entities/FormField';
+import { type FormFieldCreateInput, type FormFieldUpdateInput } from '@/shared/domain/entities/FormFieldInput';
+import { type FormFieldRepository } from '@/shared/domain/repositories/FormFieldRepository';
+import { type FormFieldRemoteDataSource } from '../data-sources/FormFieldRemoteDataSource';
+import { type FormFieldMapper } from '../mappers/FormFieldMapper';
+import { type ErrorMapper } from '@/data/mappers/ErrorMapper';
+import { type NetworkError } from '@/data/networking/NetworkError';
+
+export class FormFieldRepositoryImpl implements FormFieldRepository {
+  constructor(
+    private readonly dataSource: FormFieldRemoteDataSource,
+    private readonly mapper: FormFieldMapper,
+    private readonly errorMapper: ErrorMapper,
+  ) {}
+
+  async getAll(companyId: string): Promise<FormField[]> {
+    try {
+      const dtos = await this.dataSource.getFormFields(companyId);
+      return dtos.map((dto) => this.mapper.toDomain(dto));
+    } catch (error) {
+      throw this.errorMapper.toDomain(error as NetworkError);
+    }
+  }
+
+  async create(companyId: string, input: FormFieldCreateInput): Promise<FormField> {
+    try {
+      const result = await this.dataSource.createFormField({
+        companyId,
+        label: input.label,
+        type: input.type,
+        required: input.required,
+        options: input.options?.join(',') ?? '',
+        sort_order: input.sortOrder,
+      });
+      // Re-fetch the created field by fetching all and finding by id
+      const dtos = await this.dataSource.getFormFields(companyId);
+      const dto = dtos.find((d) => d.id === result.id);
+      if (!dto) throw new Error('Created field not found after creation');
+      return this.mapper.toDomain(dto);
+    } catch (error) {
+      throw this.errorMapper.toDomain(error as NetworkError);
+    }
+  }
+
+  async update(companyId: string, fieldId: string, input: FormFieldUpdateInput): Promise<void> {
+    try {
+      await this.dataSource.updateFormField(companyId, fieldId, {
+        label: input.label,
+        type: input.type,
+        required: input.required,
+        options: input.options?.join(','),
+        enabled: input.enabled,
+      });
+    } catch (error) {
+      throw this.errorMapper.toDomain(error as NetworkError);
+    }
+  }
+
+  async delete(companyId: string, fieldId: string): Promise<void> {
+    try {
+      await this.dataSource.deleteFormField(companyId, fieldId);
+    } catch (error) {
+      throw this.errorMapper.toDomain(error as NetworkError);
+    }
+  }
+
+  async reorder(companyId: string, order: Array<{ id: string; sortOrder: number }>): Promise<void> {
+    try {
+      await this.dataSource.reorderFormFields({
+        companyId,
+        order: order.map((o) => ({ id: o.id, sort_order: o.sortOrder })),
+      });
+    } catch (error) {
+      throw this.errorMapper.toDomain(error as NetworkError);
+    }
+  }
+}

--- a/src/features/admin-form-fields/domain/use-cases/CreateFormFieldUseCase.ts
+++ b/src/features/admin-form-fields/domain/use-cases/CreateFormFieldUseCase.ts
@@ -1,0 +1,15 @@
+import { type FormField } from '@/shared/domain/entities/FormField';
+import { type FormFieldCreateInput } from '@/shared/domain/entities/FormFieldInput';
+import { type FormFieldRepository } from '@/shared/domain/repositories/FormFieldRepository';
+
+export interface CreateFormFieldUseCase {
+  execute(companyId: string, input: FormFieldCreateInput): Promise<FormField>;
+}
+
+export class CreateFormFieldUseCaseImpl implements CreateFormFieldUseCase {
+  constructor(private readonly repository: FormFieldRepository) {}
+
+  execute(companyId: string, input: FormFieldCreateInput): Promise<FormField> {
+    return this.repository.create(companyId, input);
+  }
+}

--- a/src/features/admin-form-fields/domain/use-cases/DeleteFormFieldUseCase.ts
+++ b/src/features/admin-form-fields/domain/use-cases/DeleteFormFieldUseCase.ts
@@ -1,0 +1,13 @@
+import { type FormFieldRepository } from '@/shared/domain/repositories/FormFieldRepository';
+
+export interface DeleteFormFieldUseCase {
+  execute(companyId: string, fieldId: string): Promise<void>;
+}
+
+export class DeleteFormFieldUseCaseImpl implements DeleteFormFieldUseCase {
+  constructor(private readonly repository: FormFieldRepository) {}
+
+  execute(companyId: string, fieldId: string): Promise<void> {
+    return this.repository.delete(companyId, fieldId);
+  }
+}

--- a/src/features/admin-form-fields/domain/use-cases/GetFormFieldsUseCase.ts
+++ b/src/features/admin-form-fields/domain/use-cases/GetFormFieldsUseCase.ts
@@ -1,0 +1,14 @@
+import { type FormField } from '@/shared/domain/entities/FormField';
+import { type FormFieldRepository } from '@/shared/domain/repositories/FormFieldRepository';
+
+export interface GetFormFieldsUseCase {
+  execute(companyId: string): Promise<FormField[]>;
+}
+
+export class GetFormFieldsUseCaseImpl implements GetFormFieldsUseCase {
+  constructor(private readonly repository: FormFieldRepository) {}
+
+  execute(companyId: string): Promise<FormField[]> {
+    return this.repository.getAll(companyId);
+  }
+}

--- a/src/features/admin-form-fields/domain/use-cases/ReorderFormFieldsUseCase.ts
+++ b/src/features/admin-form-fields/domain/use-cases/ReorderFormFieldsUseCase.ts
@@ -1,0 +1,13 @@
+import { type FormFieldRepository } from '@/shared/domain/repositories/FormFieldRepository';
+
+export interface ReorderFormFieldsUseCase {
+  execute(companyId: string, order: Array<{ id: string; sortOrder: number }>): Promise<void>;
+}
+
+export class ReorderFormFieldsUseCaseImpl implements ReorderFormFieldsUseCase {
+  constructor(private readonly repository: FormFieldRepository) {}
+
+  execute(companyId: string, order: Array<{ id: string; sortOrder: number }>): Promise<void> {
+    return this.repository.reorder(companyId, order);
+  }
+}

--- a/src/features/admin-form-fields/domain/use-cases/UpdateFormFieldUseCase.ts
+++ b/src/features/admin-form-fields/domain/use-cases/UpdateFormFieldUseCase.ts
@@ -1,0 +1,14 @@
+import { type FormFieldUpdateInput } from '@/shared/domain/entities/FormFieldInput';
+import { type FormFieldRepository } from '@/shared/domain/repositories/FormFieldRepository';
+
+export interface UpdateFormFieldUseCase {
+  execute(companyId: string, fieldId: string, input: FormFieldUpdateInput): Promise<void>;
+}
+
+export class UpdateFormFieldUseCaseImpl implements UpdateFormFieldUseCase {
+  constructor(private readonly repository: FormFieldRepository) {}
+
+  execute(companyId: string, fieldId: string, input: FormFieldUpdateInput): Promise<void> {
+    return this.repository.update(companyId, fieldId, input);
+  }
+}

--- a/src/features/admin-form-fields/presentation/actions/createFormFieldAction.ts
+++ b/src/features/admin-form-fields/presentation/actions/createFormFieldAction.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { z } from 'zod';
+import { authActionClient } from '@/lib/safe-action';
+import { createFormFieldUseCase } from '@/di/container.server';
+import { DomainError } from '@/shared/domain/errors/DomainError';
+
+const schema = z.object({
+  companyId: z.string().min(1),
+  label: z.string().min(1, 'Label is required.'),
+  type: z.enum(['text', 'textarea', 'email', 'tel', 'url', 'number', 'date', 'select', 'file']),
+  required: z.boolean(),
+  options: z.array(z.string()).optional(),
+  sortOrder: z.number().optional(),
+});
+
+export const createFormFieldAction = authActionClient
+  .schema(schema)
+  .action(async ({ parsedInput, ctx: { session } }) => {
+    if (session.role === 'COMPANY_ADMIN' && parsedInput.companyId !== session.companyId) {
+      throw DomainError.unauthorized();
+    }
+    const { companyId, ...input } = parsedInput;
+    return createFormFieldUseCase.execute(companyId, input);
+  });

--- a/src/features/admin-form-fields/presentation/actions/deleteFormFieldAction.ts
+++ b/src/features/admin-form-fields/presentation/actions/deleteFormFieldAction.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { z } from 'zod';
+import { authActionClient } from '@/lib/safe-action';
+import { deleteFormFieldUseCase } from '@/di/container.server';
+import { DomainError } from '@/shared/domain/errors/DomainError';
+
+const schema = z.object({
+  companyId: z.string().min(1),
+  fieldId: z.string().min(1),
+});
+
+export const deleteFormFieldAction = authActionClient
+  .schema(schema)
+  .action(async ({ parsedInput, ctx: { session } }) => {
+    if (session.role === 'COMPANY_ADMIN' && parsedInput.companyId !== session.companyId) {
+      throw DomainError.unauthorized();
+    }
+    await deleteFormFieldUseCase.execute(parsedInput.companyId, parsedInput.fieldId);
+  });

--- a/src/features/admin-form-fields/presentation/actions/reorderFormFieldsAction.ts
+++ b/src/features/admin-form-fields/presentation/actions/reorderFormFieldsAction.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { z } from 'zod';
+import { authActionClient } from '@/lib/safe-action';
+import { reorderFormFieldsUseCase } from '@/di/container.server';
+import { DomainError } from '@/shared/domain/errors/DomainError';
+
+const schema = z.object({
+  companyId: z.string().min(1),
+  order: z.array(z.object({ id: z.string(), sortOrder: z.number() })),
+});
+
+export const reorderFormFieldsAction = authActionClient
+  .schema(schema)
+  .action(async ({ parsedInput, ctx: { session } }) => {
+    if (session.role === 'COMPANY_ADMIN' && parsedInput.companyId !== session.companyId) {
+      throw DomainError.unauthorized();
+    }
+    await reorderFormFieldsUseCase.execute(parsedInput.companyId, parsedInput.order);
+  });

--- a/src/features/admin-form-fields/presentation/actions/updateFormFieldAction.ts
+++ b/src/features/admin-form-fields/presentation/actions/updateFormFieldAction.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { z } from 'zod';
+import { authActionClient } from '@/lib/safe-action';
+import { updateFormFieldUseCase } from '@/di/container.server';
+import { DomainError } from '@/shared/domain/errors/DomainError';
+
+const schema = z.object({
+  companyId: z.string().min(1),
+  fieldId: z.string().min(1),
+  label: z.string().min(1).optional(),
+  type: z.enum(['text', 'textarea', 'email', 'tel', 'url', 'number', 'date', 'select', 'file']).optional(),
+  required: z.boolean().optional(),
+  options: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const updateFormFieldAction = authActionClient
+  .schema(schema)
+  .action(async ({ parsedInput, ctx: { session } }) => {
+    if (session.role === 'COMPANY_ADMIN' && parsedInput.companyId !== session.companyId) {
+      throw DomainError.unauthorized();
+    }
+    const { companyId, fieldId, ...input } = parsedInput;
+    await updateFormFieldUseCase.execute(companyId, fieldId, input);
+  });

--- a/src/features/admin-form-fields/presentation/views/FormFieldsManagerView.tsx
+++ b/src/features/admin-form-fields/presentation/views/FormFieldsManagerView.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { type FormField } from '@/shared/domain/entities/FormField';
+import { useFormFieldsManagerViewModel } from './useFormFieldsManagerViewModel';
+
+const FIELD_TYPE_OPTIONS = [
+  { value: 'text',     label: 'Text' },
+  { value: 'textarea', label: 'Textarea' },
+  { value: 'email',    label: 'Email' },
+  { value: 'tel',      label: 'Phone' },
+  { value: 'url',      label: 'URL' },
+  { value: 'number',   label: 'Number' },
+  { value: 'date',     label: 'Date' },
+  { value: 'select',   label: 'Select (dropdown)' },
+] as const;
+
+const TYPE_BADGE: Record<string, string> = {
+  text:     'bg-gray-100 text-gray-600',
+  textarea: 'bg-blue-50 text-blue-600',
+  email:    'bg-purple-50 text-purple-600',
+  tel:      'bg-yellow-50 text-yellow-700',
+  url:      'bg-indigo-50 text-indigo-600',
+  number:   'bg-green-50 text-green-700',
+  date:     'bg-pink-50 text-pink-600',
+  select:   'bg-orange-50 text-orange-600',
+  file:     'bg-red-50 text-red-600',
+};
+
+interface Props {
+  initialFields: FormField[];
+  companyId: string;
+}
+
+export function FormFieldsManagerView({ initialFields, companyId }: Props) {
+  const vm = useFormFieldsManagerViewModel(initialFields, companyId);
+
+  return (
+    <div className="bg-gray-50 p-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-lg shadow p-6">
+          <h1 className="text-2xl font-semibold text-gray-900 mb-1">Application Form Fields</h1>
+          <p className="text-sm text-gray-500 mb-6">
+            Customize the fields shown on your applicant form. Core fields (
+            <span className="inline-flex items-center gap-1"><LockIcon />locked</span>) cannot be
+            removed.
+          </p>
+
+          <div className="space-y-2 mb-6">
+            {vm.fields.map((field, index) => (
+              <FieldRow
+                key={field.id}
+                field={field}
+                index={index}
+                total={vm.fields.length}
+                isCore={vm.isCore(field)}
+                onToggleEnabled={() => vm.onToggleEnabled(field)}
+                onToggleRequired={() => vm.onToggleRequired(field)}
+                onDelete={() => vm.onDelete(field)}
+                onMoveUp={() => vm.onMoveUp(index)}
+                onMoveDown={() => vm.onMoveDown(index)}
+              />
+            ))}
+          </div>
+
+          {vm.showAddForm ? (
+            <div className="border border-blue-200 rounded-lg p-4 bg-blue-50 space-y-3">
+              <p className="text-sm font-medium text-blue-900">New Field</p>
+
+              {vm.addError && (
+                <p className="text-sm text-red-600">{vm.addError}</p>
+              )}
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">Label *</label>
+                  <input
+                    type="text"
+                    value={vm.addForm.label}
+                    onChange={(e) => vm.onAddFormChange({ label: e.target.value })}
+                    placeholder="e.g. Years of Experience"
+                    className="w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">Type</label>
+                  <select
+                    value={vm.addForm.type}
+                    onChange={(e) => vm.onAddFormChange({ type: e.target.value as typeof vm.addForm.type })}
+                    className="w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    {FIELD_TYPE_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              {vm.addForm.type === 'select' && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">
+                    Options <span className="text-gray-400">(comma-separated)</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={vm.addForm.options}
+                    onChange={(e) => vm.onAddFormChange({ options: e.target.value })}
+                    placeholder="Option 1, Option 2, Option 3"
+                    className="w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              )}
+
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="addRequired"
+                  checked={vm.addForm.required}
+                  onChange={(e) => vm.onAddFormChange({ required: e.target.checked })}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <label htmlFor="addRequired" className="text-sm text-gray-700">Required</label>
+              </div>
+
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={vm.onAddFieldSubmit}
+                  disabled={vm.isCreating}
+                  className="cursor-pointer bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded px-4 py-2 transition-colors"
+                >
+                  {vm.isCreating ? 'Adding…' : 'Add Field'}
+                </button>
+                <button
+                  onClick={vm.onCancelAddForm}
+                  className="cursor-pointer bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded px-4 py-2 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={vm.onShowAddForm}
+              className="cursor-pointer w-full border-2 border-dashed border-gray-300 hover:border-blue-400 hover:bg-blue-50 rounded-lg py-3 text-sm text-gray-500 hover:text-blue-600 transition-colors"
+            >
+              + Add custom field
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface FieldRowProps {
+  field: FormField;
+  index: number;
+  total: number;
+  isCore: boolean;
+  onToggleEnabled(): void;
+  onToggleRequired(): void;
+  onDelete(): void;
+  onMoveUp(): void;
+  onMoveDown(): void;
+}
+
+function FieldRow({
+  field,
+  index,
+  total,
+  isCore,
+  onToggleEnabled,
+  onToggleRequired,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: FieldRowProps) {
+  const badgeClass = TYPE_BADGE[field.type] ?? 'bg-gray-100 text-gray-600';
+
+  return (
+    <div className={`flex items-center gap-3 rounded-lg border px-4 py-3 text-sm ${field.enabled ? 'bg-white border-gray-200' : 'bg-gray-50 border-gray-200 opacity-60'}`}>
+      {/* Reorder arrows */}
+      <div className="flex flex-col gap-0.5 shrink-0">
+        <button
+          onClick={onMoveUp}
+          disabled={index === 0}
+          className="cursor-pointer text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed leading-none"
+          title="Move up"
+        >
+          ▲
+        </button>
+        <button
+          onClick={onMoveDown}
+          disabled={index === total - 1}
+          className="cursor-pointer text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed leading-none"
+          title="Move down"
+        >
+          ▼
+        </button>
+      </div>
+
+      {/* Label */}
+      <span className="flex-1 font-medium text-gray-800 min-w-0 truncate">{field.label}</span>
+
+      {/* Type badge */}
+      <span className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded ${badgeClass}`}>
+        {field.type}
+      </span>
+
+      {/* Required badge */}
+      {field.required && (
+        <span className="shrink-0 text-xs text-red-500 font-medium">required</span>
+      )}
+
+      {/* Lock icon for core system fields */}
+      {isCore ? (
+        <span className="shrink-0 text-gray-400" title="Core system field — cannot be modified">
+          <LockIcon />
+        </span>
+      ) : (
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Toggle required (optional system + custom) */}
+          <button
+            onClick={onToggleRequired}
+            className={`cursor-pointer text-xs px-2 py-0.5 rounded border transition-colors ${
+              field.required
+                ? 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100'
+                : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-50'
+            }`}
+            title={field.required ? 'Make optional' : 'Make required'}
+          >
+            {field.required ? 'req' : 'opt'}
+          </button>
+
+          {/* Toggle enabled (optional system + custom) */}
+          <button
+            onClick={onToggleEnabled}
+            className={`cursor-pointer text-xs px-2 py-0.5 rounded border transition-colors ${
+              field.enabled
+                ? 'border-green-300 bg-green-50 text-green-700 hover:bg-green-100'
+                : 'border-gray-300 bg-white text-gray-400 hover:bg-gray-50'
+            }`}
+            title={field.enabled ? 'Disable field' : 'Enable field'}
+          >
+            {field.enabled ? 'on' : 'off'}
+          </button>
+
+          {/* Delete (custom only) */}
+          {!field.isSystem && (
+            <button
+              onClick={onDelete}
+              className="cursor-pointer text-gray-400 hover:text-red-500 transition-colors"
+              title="Delete field"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-3.5 w-3.5 inline"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        fillRule="evenodd"
+        d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/src/features/admin-form-fields/presentation/views/useFormFieldsManagerViewModel.ts
+++ b/src/features/admin-form-fields/presentation/views/useFormFieldsManagerViewModel.ts
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState } from 'react';
+import { useAction } from 'next-safe-action/hooks';
+import { type FormField, type FormFieldType } from '@/shared/domain/entities/FormField';
+import { createFormFieldAction } from '../actions/createFormFieldAction';
+import { updateFormFieldAction } from '../actions/updateFormFieldAction';
+import { deleteFormFieldAction } from '../actions/deleteFormFieldAction';
+import { reorderFormFieldsAction } from '../actions/reorderFormFieldsAction';
+
+/** The 7 core system field names that can never be disabled or deleted */
+const CORE_FIELD_NAMES = new Set([
+  'full_name',
+  'email',
+  'phone',
+  'city',
+  'experience_summary',
+  'expected_salary',
+  'cv_url',
+]);
+
+interface AddFieldForm {
+  label: string;
+  type: FormFieldType;
+  required: boolean;
+  options: string; // comma-separated for select type
+}
+
+const DEFAULT_ADD_FORM: AddFieldForm = {
+  label: '',
+  type: 'text',
+  required: false,
+  options: '',
+};
+
+export function useFormFieldsManagerViewModel(
+  initialFields: FormField[],
+  companyId: string,
+) {
+  const [fields, setFields] = useState<FormField[]>(
+    [...initialFields].sort((a, b) => a.sortOrder - b.sortOrder),
+  );
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addForm, setAddForm] = useState<AddFieldForm>(DEFAULT_ADD_FORM);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const { execute: execCreate, isPending: isCreating } = useAction(createFormFieldAction, {
+    onSuccess: ({ data }) => {
+      if (data) {
+        setFields((prev) =>
+          [...prev, data].sort((a, b) => a.sortOrder - b.sortOrder),
+        );
+        setShowAddForm(false);
+        setAddForm(DEFAULT_ADD_FORM);
+        setAddError(null);
+      }
+    },
+    onError: () => setAddError('Failed to create field. Please try again.'),
+  });
+
+  const { execute: execUpdate } = useAction(updateFormFieldAction);
+  const { execute: execDelete } = useAction(deleteFormFieldAction);
+  const { execute: execReorder } = useAction(reorderFormFieldsAction);
+
+  function isCore(field: FormField) {
+    return CORE_FIELD_NAMES.has(field.fieldName);
+  }
+
+  function onToggleEnabled(field: FormField) {
+    if (isCore(field)) return;
+    const enabled = !field.enabled;
+    setFields((prev) =>
+      prev.map((f) => (f.id === field.id ? { ...f, enabled } : f)),
+    );
+    execUpdate({ companyId, fieldId: field.id, enabled });
+  }
+
+  function onToggleRequired(field: FormField) {
+    if (isCore(field)) return;
+    const required = !field.required;
+    setFields((prev) =>
+      prev.map((f) => (f.id === field.id ? { ...f, required } : f)),
+    );
+    execUpdate({ companyId, fieldId: field.id, required });
+  }
+
+  function onDelete(field: FormField) {
+    if (field.isSystem) return;
+    setFields((prev) => prev.filter((f) => f.id !== field.id));
+    execDelete({ companyId, fieldId: field.id });
+  }
+
+  function onMoveUp(index: number) {
+    if (index === 0) return;
+    const next = [...fields];
+    [next[index - 1], next[index]] = [next[index], next[index - 1]];
+    const reordered = next.map((f, i) => ({ ...f, sortOrder: i + 1 }));
+    setFields(reordered);
+    execReorder({
+      companyId,
+      order: reordered.map((f) => ({ id: f.id, sortOrder: f.sortOrder })),
+    });
+  }
+
+  function onMoveDown(index: number) {
+    if (index === fields.length - 1) return;
+    const next = [...fields];
+    [next[index], next[index + 1]] = [next[index + 1], next[index]];
+    const reordered = next.map((f, i) => ({ ...f, sortOrder: i + 1 }));
+    setFields(reordered);
+    execReorder({
+      companyId,
+      order: reordered.map((f) => ({ id: f.id, sortOrder: f.sortOrder })),
+    });
+  }
+
+  function onAddFieldSubmit() {
+    if (!addForm.label.trim()) {
+      setAddError('Label is required.');
+      return;
+    }
+    setAddError(null);
+    execCreate({
+      companyId,
+      label: addForm.label.trim(),
+      type: addForm.type,
+      required: addForm.required,
+      options: addForm.type === 'select'
+        ? addForm.options.split(',').map((o) => o.trim()).filter(Boolean)
+        : [],
+    });
+  }
+
+  return {
+    fields,
+    showAddForm,
+    addForm,
+    addError,
+    isCreating,
+    isCore,
+    onToggleEnabled,
+    onToggleRequired,
+    onDelete,
+    onMoveUp,
+    onMoveDown,
+    onShowAddForm: () => setShowAddForm(true),
+    onCancelAddForm: () => { setShowAddForm(false); setAddForm(DEFAULT_ADD_FORM); setAddError(null); },
+    onAddFormChange: (patch: Partial<AddFieldForm>) => setAddForm((prev) => ({ ...prev, ...patch })),
+    onAddFieldSubmit,
+  };
+}

--- a/src/features/admin-jobs/presentation/organisms/DeleteJobDialog.tsx
+++ b/src/features/admin-jobs/presentation/organisms/DeleteJobDialog.tsx
@@ -13,7 +13,7 @@ export function DeleteJobDialog({ jobTitle, open, isPending, serverError, onOpen
     <>
       <button
         onClick={onOpen}
-        className="text-xs text-red-600 hover:text-red-800 font-medium transition-colors"
+        className="cursor-pointer text-xs text-red-600 hover:text-red-800 font-medium transition-colors"
       >
         Delete
       </button>
@@ -43,7 +43,7 @@ export function DeleteJobDialog({ jobTitle, open, isPending, serverError, onOpen
                 type="button"
                 onClick={onClose}
                 disabled={isPending}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded transition-colors disabled:opacity-50"
+                className="cursor-pointer px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>
@@ -51,7 +51,7 @@ export function DeleteJobDialog({ jobTitle, open, isPending, serverError, onOpen
                 type="button"
                 onClick={onConfirm}
                 disabled={isPending}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors disabled:opacity-50"
+                className="cursor-pointer px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isPending ? 'Deleting…' : 'Delete'}
               </button>

--- a/src/features/admin-jobs/presentation/views/JobFormView.tsx
+++ b/src/features/admin-jobs/presentation/views/JobFormView.tsx
@@ -147,7 +147,7 @@ export function JobFormView({ companyId, job, mode }: Props) {
             <button
               type="submit"
               disabled={vm.isPending}
-              className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded px-4 py-2 transition-colors"
+              className="w-full cursor-pointer bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded px-4 py-2 transition-colors"
             >
               {vm.isPending
                 ? mode === 'create'

--- a/src/features/admin-onboarding/presentation/organisms/Step1ProfileFormOrganism.tsx
+++ b/src/features/admin-onboarding/presentation/organisms/Step1ProfileFormOrganism.tsx
@@ -28,7 +28,7 @@ const inputClass =
   'w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500';
 
 const primaryButtonClass =
-  'rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors';
+  'cursor-pointer rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
 
 export function Step1ProfileFormOrganism({
   fields,

--- a/src/features/admin-onboarding/presentation/organisms/Step2DriveSetupOrganism.tsx
+++ b/src/features/admin-onboarding/presentation/organisms/Step2DriveSetupOrganism.tsx
@@ -36,7 +36,7 @@ export function Step2DriveSetupOrganism({ slug, onContinue }: Props) {
 
       <button
         onClick={onContinue}
-        className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        className="cursor-pointer rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
         I&apos;ve completed setup →
       </button>

--- a/src/features/admin-onboarding/presentation/organisms/Step3VerifyConnectionOrganism.tsx
+++ b/src/features/admin-onboarding/presentation/organisms/Step3VerifyConnectionOrganism.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const primaryButtonClass =
-  'rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors';
+  'cursor-pointer rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
 
 export function Step3VerifyConnectionOrganism({
   slug,
@@ -54,7 +54,7 @@ export function Step3VerifyConnectionOrganism({
         <button
           onClick={onVerify}
           disabled={isPending}
-          className="mt-2 ml-2 rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 transition-colors"
+          className="cursor-pointer mt-2 ml-2 rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           Retry
         </button>

--- a/src/features/admin-onboarding/presentation/organisms/Step4LaunchOrganism.tsx
+++ b/src/features/admin-onboarding/presentation/organisms/Step4LaunchOrganism.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const primaryButtonClass =
-  'rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors';
+  'cursor-pointer rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
 
 export function Step4LaunchOrganism({ slug, isPending, serverError, onLaunch }: Props) {
   return (

--- a/src/features/admin-settings/presentation/organisms/CompanySelectorWidget.tsx
+++ b/src/features/admin-settings/presentation/organisms/CompanySelectorWidget.tsx
@@ -9,9 +9,10 @@ interface Props {
   readonly?: boolean;
   onGoToJobs: (companyId: string) => void;
   onGoToSettings: (companyId: string) => void;
+  onGoToFormFields: (companyId: string) => void;
 }
 
-export function CompanySelectorWidget({ companies, selectedId, onSelectionChange, readonly = false, onGoToJobs, onGoToSettings }: Props) {
+export function CompanySelectorWidget({ companies, selectedId, onSelectionChange, readonly = false, onGoToJobs, onGoToSettings, onGoToFormFields }: Props) {
   return (
     <div className="flex gap-2 items-center">
       <select
@@ -29,16 +30,23 @@ export function CompanySelectorWidget({ companies, selectedId, onSelectionChange
       <button
         onClick={() => onGoToJobs(selectedId)}
         disabled={!selectedId}
-        className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded px-4 py-2 transition-colors"
+        className="cursor-pointer bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded px-4 py-2 transition-colors"
       >
         Manage Jobs
       </button>
       <button
         onClick={() => onGoToSettings(selectedId)}
         disabled={!selectedId}
-        className="bg-white hover:bg-gray-50 disabled:opacity-50 text-gray-700 border border-gray-300 text-sm font-medium rounded px-4 py-2 transition-colors"
+        className="cursor-pointer bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed text-gray-700 border border-gray-300 text-sm font-medium rounded px-4 py-2 transition-colors"
       >
         Settings
+      </button>
+      <button
+        onClick={() => onGoToFormFields(selectedId)}
+        disabled={!selectedId}
+        className="cursor-pointer bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed text-gray-700 border border-gray-300 text-sm font-medium rounded px-4 py-2 transition-colors"
+      >
+        Form Fields
       </button>
     </div>
   );

--- a/src/features/admin-settings/presentation/settings/CompanySettingsView.tsx
+++ b/src/features/admin-settings/presentation/settings/CompanySettingsView.tsx
@@ -137,7 +137,7 @@ export function CompanySettingsView({ defaultValues, companyId }: Props) {
             <button
               type="submit"
               disabled={vm.isPending}
-              className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded px-4 py-2 transition-colors"
+              className="w-full cursor-pointer bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded px-4 py-2 transition-colors"
             >
               {vm.isPending ? 'Saving…' : 'Save Settings'}
             </button>

--- a/src/features/admin-settings/presentation/views/AdminDashboardView.tsx
+++ b/src/features/admin-settings/presentation/views/AdminDashboardView.tsx
@@ -20,6 +20,7 @@ export function AdminDashboardView({ companies, readonly = false }: Props) {
       readonly={readonly}
       onGoToJobs={vm.onGoToJobs}
       onGoToSettings={vm.onGoToSettings}
+      onGoToFormFields={vm.onGoToFormFields}
     />
   );
 }

--- a/src/features/admin-settings/presentation/views/useAdminDashboardViewModel.ts
+++ b/src/features/admin-settings/presentation/views/useAdminDashboardViewModel.ts
@@ -17,5 +17,6 @@ export function useAdminDashboardViewModel({ companies }: Props) {
     onSelectionChange: (id: string) => setSelectedId(id),
     onGoToJobs: (id: string) => router.push(`/admin/jobs?companyId=${id}`),
     onGoToSettings: (id: string) => router.push(`/admin/settings?companyId=${id}`),
+    onGoToFormFields: (id: string) => router.push(`/admin/form-fields?companyId=${id}`),
   };
 }

--- a/src/features/career-microsite/data/repositories/ApplicationRepositoryImpl.ts
+++ b/src/features/career-microsite/data/repositories/ApplicationRepositoryImpl.ts
@@ -27,6 +27,11 @@ export class ApplicationRepositoryImpl implements ApplicationRepository {
     if (payload.portfolioUrl) formData.append('portfolioUrl', payload.portfolioUrl);
     if (payload.coverLetter) formData.append('coverLetter', payload.coverLetter);
     if (payload.screeningScore != null) formData.append('screeningScore', String(payload.screeningScore));
+    if (payload.customFields) {
+      for (const [key, value] of Object.entries(payload.customFields)) {
+        formData.append(key, String(value));
+      }
+    }
 
     try {
       await this.dataSource.submitApplication(formData);

--- a/src/features/career-microsite/presentation/apply-form/ApplyFormView.tsx
+++ b/src/features/career-microsite/presentation/apply-form/ApplyFormView.tsx
@@ -2,16 +2,26 @@
 
 import { type Company } from '@/shared/domain/entities/Company';
 import { type Job } from '@/shared/domain/entities/Job';
+import { type FormField } from '@/shared/domain/entities/FormField';
 import { type ApplyFormViewModel } from './useApplyFormViewModel';
+import { SYSTEM_FIELD_FORM_KEY } from './buildApplicationFormSchema';
 
 interface Props {
   company: Company;
   job: Job;
+  formFields: FormField[];
   vm: ApplyFormViewModel;
 }
 
-export function ApplyFormView({ company, job, vm }: Props) {
+const INPUT_CLASS =
+  'w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]';
+
+export function ApplyFormView({ company, job, formFields, vm }: Props) {
   const { isSubmitting, error, fieldErrors, handleSubmit, handleCvFileChange } = vm;
+
+  const enabledFields = formFields
+    .filter((f) => f.enabled)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -25,65 +35,14 @@ export function ApplyFormView({ company, job, vm }: Props) {
         <p className="text-sm text-zinc-500 mb-8">{company.name}</p>
 
         <form onSubmit={onSubmit} noValidate className="bg-white rounded-lg border border-zinc-200 p-8 space-y-5">
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="fullName">Full Name *</label>
-            <input id="fullName" name="fullName" type="text" required className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['fullName'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['fullName']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="email">Email *</label>
-            <input id="email" name="email" type="email" required className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['email'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['email']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="phone">Phone *</label>
-            <input id="phone" name="phone" type="tel" required className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['phone'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['phone']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="city">City *</label>
-            <input id="city" name="city" type="text" required className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['city'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['city']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="experienceSummary">Experience Summary *</label>
-            <textarea id="experienceSummary" name="experienceSummary" required rows={4} className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['experienceSummary'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['experienceSummary']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="expectedSalary">Expected Salary (IDR) *</label>
-            <input id="expectedSalary" name="expectedSalary" type="number" required min={0} className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['expectedSalary'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['expectedSalary']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="cvFile">CV / Resume *</label>
-            <input id="cvFile" name="cvFile" type="file" required accept=".pdf,.doc,.docx" onChange={handleCvFileChange} className="w-full text-sm text-zinc-600" />
-            {fieldErrors?.['cvFile'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['cvFile']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="linkedinUrl">LinkedIn URL</label>
-            <input id="linkedinUrl" name="linkedinUrl" type="url" className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['linkedinUrl'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['linkedinUrl']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="portfolioUrl">Portfolio URL</label>
-            <input id="portfolioUrl" name="portfolioUrl" type="url" className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['portfolioUrl'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['portfolioUrl']}</p>}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="coverLetter">Cover Letter</label>
-            <textarea id="coverLetter" name="coverLetter" rows={4} className="w-full border border-zinc-300 rounded-md px-3 py-2 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-            {fieldErrors?.['coverLetter'] && <p className="text-red-600 text-sm mt-1">{fieldErrors['coverLetter']}</p>}
-          </div>
+          {enabledFields.map((field) => (
+            <FormFieldInput
+              key={field.id}
+              field={field}
+              fieldErrors={fieldErrors}
+              onCvFileChange={handleCvFileChange}
+            />
+          ))}
 
           {error && <p className="text-red-600 text-sm">{error}</p>}
 
@@ -97,5 +56,101 @@ export function ApplyFormView({ company, job, vm }: Props) {
         </form>
       </div>
     </main>
+  );
+}
+
+interface FieldInputProps {
+  field: FormField;
+  fieldErrors: Record<string, string> | null;
+  onCvFileChange(): void;
+}
+
+function FormFieldInput({ field, fieldErrors, onCvFileChange }: FieldInputProps) {
+  // System fields use their camelCase form key; custom fields use fieldName directly
+  const inputName = field.isSystem
+    ? (SYSTEM_FIELD_FORM_KEY[field.fieldName] ?? field.fieldName)
+    : field.fieldName;
+
+  const errorKey = inputName;
+  const fieldError = fieldErrors?.[errorKey];
+  const requiredMark = field.required ? ' *' : '';
+
+  // CV file is a special system field
+  if (field.fieldName === 'cv_url') {
+    return (
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor="cvFile">
+          CV / Resume{requiredMark}
+        </label>
+        <input
+          id="cvFile"
+          name="cvFile"
+          type="file"
+          required={field.required}
+          accept=".pdf,.doc,.docx"
+          onChange={onCvFileChange}
+          className="w-full text-sm text-zinc-600"
+        />
+        {fieldError && <p className="text-red-600 text-sm mt-1">{fieldError}</p>}
+      </div>
+    );
+  }
+
+  if (field.type === 'textarea') {
+    return (
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor={inputName}>
+          {field.label}{requiredMark}
+        </label>
+        <textarea
+          id={inputName}
+          name={inputName}
+          required={field.required}
+          rows={4}
+          className={INPUT_CLASS}
+        />
+        {fieldError && <p className="text-red-600 text-sm mt-1">{fieldError}</p>}
+      </div>
+    );
+  }
+
+  if (field.type === 'select') {
+    return (
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor={inputName}>
+          {field.label}{requiredMark}
+        </label>
+        <select
+          id={inputName}
+          name={inputName}
+          required={field.required}
+          className={INPUT_CLASS}
+        >
+          {!field.required && <option value="">— Select —</option>}
+          {field.options.map((opt) => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+        {fieldError && <p className="text-red-600 text-sm mt-1">{fieldError}</p>}
+      </div>
+    );
+  }
+
+  // All other types (text, email, tel, url, number, date, file)
+  return (
+    <div>
+      <label className="block text-sm font-medium text-zinc-700 mb-1" htmlFor={inputName}>
+        {field.label}{requiredMark}
+      </label>
+      <input
+        id={inputName}
+        name={inputName}
+        type={field.type}
+        required={field.required}
+        {...(field.type === 'number' ? { min: 0 } : {})}
+        className={INPUT_CLASS}
+      />
+      {fieldError && <p className="text-red-600 text-sm mt-1">{fieldError}</p>}
+    </div>
   );
 }

--- a/src/features/career-microsite/presentation/apply-form/__tests__/useApplyFormViewModel.test.ts
+++ b/src/features/career-microsite/presentation/apply-form/__tests__/useApplyFormViewModel.test.ts
@@ -4,6 +4,7 @@ import { useApplyFormViewModel } from '../useApplyFormViewModel';
 import { type SubmitApplicationUseCase } from '../../../domain/use-cases/SubmitApplicationUseCase';
 import { type Company } from '../../../domain/entities/Company';
 import { type Job } from '../../../domain/entities/Job';
+import { type FormField } from '@/shared/domain/entities/FormField';
 import { DomainError } from '@/shared/domain/errors/DomainError';
 
 // ---------------------------------------------------------------------------
@@ -45,6 +46,19 @@ const job: Job = {
   sortOrder: 1,
 };
 
+const DEFAULT_FORM_FIELDS: FormField[] = [
+  { id: 'sys_1',  label: 'Full Name',          fieldName: 'full_name',          type: 'text',     required: true,  options: [], sortOrder: 1,  enabled: true, isSystem: true },
+  { id: 'sys_2',  label: 'Email',              fieldName: 'email',              type: 'email',    required: true,  options: [], sortOrder: 2,  enabled: true, isSystem: true },
+  { id: 'sys_3',  label: 'Phone',              fieldName: 'phone',              type: 'tel',      required: true,  options: [], sortOrder: 3,  enabled: true, isSystem: true },
+  { id: 'sys_4',  label: 'City',               fieldName: 'city',               type: 'text',     required: true,  options: [], sortOrder: 4,  enabled: true, isSystem: true },
+  { id: 'sys_5',  label: 'Experience Summary', fieldName: 'experience_summary', type: 'textarea', required: true,  options: [], sortOrder: 5,  enabled: true, isSystem: true },
+  { id: 'sys_6',  label: 'Expected Salary',    fieldName: 'expected_salary',    type: 'number',   required: true,  options: [], sortOrder: 6,  enabled: true, isSystem: true },
+  { id: 'sys_7',  label: 'CV / Resume',        fieldName: 'cv_url',             type: 'file',     required: true,  options: [], sortOrder: 7,  enabled: true, isSystem: true },
+  { id: 'sys_8',  label: 'LinkedIn URL',       fieldName: 'linkedin_url',       type: 'url',      required: false, options: [], sortOrder: 8,  enabled: true, isSystem: true },
+  { id: 'sys_9',  label: 'Portfolio URL',      fieldName: 'portfolio_url',      type: 'url',      required: false, options: [], sortOrder: 9,  enabled: true, isSystem: true },
+  { id: 'sys_10', label: 'Cover Letter',       fieldName: 'cover_letter',       type: 'textarea', required: false, options: [], sortOrder: 10, enabled: true, isSystem: true },
+];
+
 function buildFormData(overrides: Record<string, string | File> = {}): FormData {
   const fd = new FormData();
   const defaults: Record<string, string | File> = {
@@ -78,7 +92,7 @@ function setup(submitExecute: SubmitApplicationUseCase['execute'] = vi.fn().mock
   const submitUseCase: SubmitApplicationUseCase = { execute: submitExecute };
   const onSuccess = vi.fn();
   const { result } = renderHook(() =>
-    useApplyFormViewModel(company, job, submitUseCase, onSuccess),
+    useApplyFormViewModel(company, job, submitUseCase, onSuccess, DEFAULT_FORM_FIELDS),
   );
   return { result, submitUseCase, onSuccess };
 }

--- a/src/features/career-microsite/presentation/apply-form/buildApplicationFormSchema.ts
+++ b/src/features/career-microsite/presentation/apply-form/buildApplicationFormSchema.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+import { type FormField } from '@/shared/domain/entities/FormField';
+
+const CV_MAX_BYTES = 5 * 1024 * 1024;
+
+const optionalUrl = z
+  .union([z.literal(''), z.string().url('Please enter a valid URL.')])
+  .transform((v) => v || undefined);
+
+/**
+ * Maps system field_names to the camelCase FormData keys used by the
+ * apply form HTML inputs (kept for backward compatibility with the
+ * Apps Script submission handler).
+ */
+export const SYSTEM_FIELD_FORM_KEY: Record<string, string> = {
+  full_name:          'fullName',
+  email:              'email',
+  phone:              'phone',
+  city:               'city',
+  experience_summary: 'experienceSummary',
+  expected_salary:    'expectedSalary',
+  cv_url:             'cvFile',
+  linkedin_url:       'linkedinUrl',
+  portfolio_url:      'portfolioUrl',
+  cover_letter:       'coverLetter',
+};
+
+const SYSTEM_FIELD_SCHEMAS: Record<string, z.ZodTypeAny> = {
+  fullName:          z.string().min(1, 'Full name is required.'),
+  email:             z.string().email('Please enter a valid email address.'),
+  phone:             z.string().min(1, 'Phone number is required.'),
+  city:              z.string().min(1, 'City is required.'),
+  experienceSummary: z.string().min(1, 'Experience summary is required.'),
+  expectedSalary:    z.coerce.number().min(0, 'Expected salary must be 0 or more.'),
+  cvFile:            z
+                       .instanceof(File)
+                       .refine((f) => f.size > 0, 'Please attach your CV.')
+                       .refine((f) => f.size <= CV_MAX_BYTES, 'CV file must be 5 MB or smaller.'),
+  linkedinUrl:       optionalUrl.optional(),
+  portfolioUrl:      optionalUrl.optional(),
+  coverLetter:       z.string().optional().transform((v) => v || undefined),
+};
+
+/**
+ * Builds a Zod schema from the enabled form fields for a company.
+ * System fields use their hardcoded validators.
+ * Custom fields are validated based on their type + required flag.
+ *
+ * Returns the schema and a map of which keys are custom field names
+ * (used by the ViewModel to separate customFields from system fields).
+ */
+export function buildApplicationFormSchema(formFields: FormField[]) {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const customFieldNames = new Set<string>();
+
+  for (const field of formFields) {
+    if (!field.enabled) continue;
+
+    if (field.isSystem) {
+      const formKey = SYSTEM_FIELD_FORM_KEY[field.fieldName];
+      if (!formKey) continue;
+
+      // Optional system fields can be made required by admin
+      if (formKey === 'linkedinUrl' && field.required) {
+        shape[formKey] = z.string().url('Please enter a valid URL.').min(1, 'LinkedIn URL is required.');
+      } else if (formKey === 'portfolioUrl' && field.required) {
+        shape[formKey] = z.string().url('Please enter a valid URL.').min(1, 'Portfolio URL is required.');
+      } else if (formKey === 'coverLetter' && field.required) {
+        shape[formKey] = z.string().min(1, 'Cover letter is required.');
+      } else {
+        shape[formKey] = SYSTEM_FIELD_SCHEMAS[formKey];
+      }
+    } else {
+      customFieldNames.add(field.fieldName);
+      let schema: z.ZodTypeAny;
+      switch (field.type) {
+        case 'number':
+          schema = field.required
+            ? z.coerce.number().min(0, `${field.label} is required.`)
+            : z.coerce.number().optional();
+          break;
+        case 'email':
+          schema = field.required
+            ? z.string().email('Please enter a valid email address.')
+            : z.union([z.literal(''), z.string().email()]).optional();
+          break;
+        case 'url':
+          schema = field.required
+            ? z.string().url('Please enter a valid URL.').min(1, `${field.label} is required.`)
+            : optionalUrl.optional();
+          break;
+        default:
+          schema = field.required
+            ? z.string().min(1, `${field.label} is required.`)
+            : z.string().optional();
+      }
+      shape[field.fieldName] = schema;
+    }
+  }
+
+  return { schema: z.object(shape), customFieldNames };
+}

--- a/src/features/career-microsite/presentation/apply-form/useApplyFormViewModel.ts
+++ b/src/features/career-microsite/presentation/apply-form/useApplyFormViewModel.ts
@@ -3,9 +3,10 @@
 import { useState } from 'react';
 import { type Company } from '@/shared/domain/entities/Company';
 import { type Job } from '@/shared/domain/entities/Job';
+import { type FormField } from '@/shared/domain/entities/FormField';
 import { type SubmitApplicationUseCase } from '../../domain/use-cases/SubmitApplicationUseCase';
 import { DomainError } from '@/shared/domain/errors/DomainError';
-import { applicationFormSchema } from './applicationFormSchema';
+import { buildApplicationFormSchema, SYSTEM_FIELD_FORM_KEY } from './buildApplicationFormSchema';
 
 export interface ApplyFormViewModel {
   isSubmitting: boolean;
@@ -20,6 +21,7 @@ export function useApplyFormViewModel(
   job: Job,
   submitUseCase: SubmitApplicationUseCase,
   onSuccess: () => void,
+  formFields: FormField[],
 ): ApplyFormViewModel {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -39,18 +41,21 @@ export function useApplyFormViewModel(
     setError(null);
     setFieldErrors(null);
 
-    const result = applicationFormSchema.safeParse({
-      fullName:          formData.get('fullName'),
-      email:             formData.get('email'),
-      phone:             formData.get('phone'),
-      city:              formData.get('city'),
-      experienceSummary: formData.get('experienceSummary'),
-      expectedSalary:    formData.get('expectedSalary'),
-      cvFile:            formData.get('cvFile'),
-      linkedinUrl:       formData.get('linkedinUrl'),
-      portfolioUrl:      formData.get('portfolioUrl'),
-      coverLetter:       formData.get('coverLetter'),
-    });
+    const { schema, customFieldNames } = buildApplicationFormSchema(formFields);
+
+    // Build parse input: system fields with camelCase keys, custom with fieldName
+    const parseInput: Record<string, unknown> = {};
+    for (const field of formFields) {
+      if (!field.enabled) continue;
+      if (field.isSystem) {
+        const formKey = SYSTEM_FIELD_FORM_KEY[field.fieldName];
+        if (formKey) parseInput[formKey] = formData.get(formKey);
+      } else {
+        parseInput[field.fieldName] = formData.get(field.fieldName);
+      }
+    }
+
+    const result = schema.safeParse(parseInput);
 
     if (!result.success) {
       const flat = result.error.flatten().fieldErrors;
@@ -64,22 +69,42 @@ export function useApplyFormViewModel(
     }
 
     try {
-      const file = result.data.cvFile;
+      const data = result.data as Record<string, unknown>;
+
+      // Extract CV file and encode to base64
+      const file = data['cvFile'] as File;
       const buffer = await file.arrayBuffer();
       const bytes = new Uint8Array(buffer);
       let binary = '';
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
       const cvBase64 = btoa(binary);
 
-      const { cvFile: _cvFile, ...rest } = result.data;
+      // Separate custom fields from system fields
+      const customFields: Record<string, string | number> = {};
+      for (const fieldName of customFieldNames) {
+        const value = data[fieldName];
+        if (value !== undefined && value !== '') {
+          customFields[fieldName] = value as string | number;
+        }
+      }
+
       await submitUseCase.execute(
         {
-          jobId: job.id,
-          companyId: company.id,
-          ...rest,
+          jobId:             job.id,
+          companyId:         company.id,
+          fullName:          data['fullName'] as string,
+          email:             data['email'] as string,
+          phone:             data['phone'] as string,
+          city:              data['city'] as string,
+          experienceSummary: data['experienceSummary'] as string,
+          expectedSalary:    data['expectedSalary'] as number,
           cvBase64,
-          cvFileName: file.name,
-          cvFileMime: file.type,
+          cvFileName:        file.name,
+          cvFileMime:        file.type,
+          linkedinUrl:       data['linkedinUrl'] as string | undefined,
+          portfolioUrl:      data['portfolioUrl'] as string | undefined,
+          coverLetter:       data['coverLetter'] as string | undefined,
+          ...(Object.keys(customFields).length > 0 ? { customFields } : {}),
         },
         company,
       );

--- a/src/shared/data/dtos/FormFieldDTO.ts
+++ b/src/shared/data/dtos/FormFieldDTO.ts
@@ -1,0 +1,11 @@
+export interface FormFieldDTO {
+  id: string;
+  label: string;
+  field_name: string;
+  type: string;
+  required: boolean | string;
+  options: string;
+  sort_order: number | string;
+  enabled: boolean | string;
+  is_system: boolean | string;
+}

--- a/src/shared/domain/entities/ApplicationPayload.ts
+++ b/src/shared/domain/entities/ApplicationPayload.ts
@@ -14,4 +14,5 @@ export interface ApplicationPayload {
   readonly portfolioUrl?: string;
   readonly coverLetter?: string;
   readonly screeningScore?: number | null;
+  readonly customFields?: Record<string, string | number>;
 }

--- a/src/shared/domain/entities/FormField.ts
+++ b/src/shared/domain/entities/FormField.ts
@@ -1,0 +1,28 @@
+export type FormFieldType =
+  | 'text'
+  | 'textarea'
+  | 'email'
+  | 'tel'
+  | 'url'
+  | 'number'
+  | 'date'
+  | 'select'
+  | 'file';
+
+export interface FormField {
+  readonly id: string;
+  readonly label: string;
+  /** snake_case key; matches column header in Candidates sheet */
+  readonly fieldName: string;
+  readonly type: FormFieldType;
+  readonly required: boolean;
+  /** Non-empty only for 'select' type */
+  readonly options: string[];
+  readonly sortOrder: number;
+  readonly enabled: boolean;
+  /**
+   * true for the 10 built-in fields.
+   * System fields cannot be deleted; the 7 core ones cannot be disabled.
+   */
+  readonly isSystem: boolean;
+}

--- a/src/shared/domain/entities/FormFieldInput.ts
+++ b/src/shared/domain/entities/FormFieldInput.ts
@@ -1,0 +1,17 @@
+import { type FormFieldType } from './FormField';
+
+export interface FormFieldCreateInput {
+  readonly label: string;
+  readonly type: FormFieldType;
+  readonly required: boolean;
+  readonly options?: string[];
+  readonly sortOrder?: number;
+}
+
+export interface FormFieldUpdateInput {
+  readonly label?: string;
+  readonly type?: FormFieldType;
+  readonly required?: boolean;
+  readonly options?: string[];
+  readonly enabled?: boolean;
+}

--- a/src/shared/domain/repositories/FormFieldRepository.ts
+++ b/src/shared/domain/repositories/FormFieldRepository.ts
@@ -1,0 +1,10 @@
+import { type FormField } from '../entities/FormField';
+import { type FormFieldCreateInput, type FormFieldUpdateInput } from '../entities/FormFieldInput';
+
+export interface FormFieldRepository {
+  getAll(companyId: string): Promise<FormField[]>;
+  create(companyId: string, input: FormFieldCreateInput): Promise<FormField>;
+  update(companyId: string, fieldId: string, input: FormFieldUpdateInput): Promise<void>;
+  delete(companyId: string, fieldId: string): Promise<void>;
+  reorder(companyId: string, order: Array<{ id: string; sortOrder: number }>): Promise<void>;
+}

--- a/src/shared/presentation/common/atoms/LogoutButton.tsx
+++ b/src/shared/presentation/common/atoms/LogoutButton.tsx
@@ -8,7 +8,7 @@ export function LogoutButton({ onLogout, isPending }: Props) {
     <button
       onClick={onLogout}
       disabled={isPending}
-      className="text-xs text-red-600 hover:text-red-800 font-medium transition-colors disabled:opacity-50"
+      className="cursor-pointer text-xs text-red-600 hover:text-red-800 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {isPending ? 'Signing out…' : 'Sign out'}
     </button>


### PR DESCRIPTION
Closes #53

## Summary

- **Apps Script** — New `Form_Fields` sheet per company (lazy-seeded with 10 defaults). Handlers for `getFormFields`, `createFormField`, `updateFormField`, `deleteFormField`, `reorderFormFields`. Candidates sheet stays in sync: column created on field add, header renamed on label update, `[deleted]_` prefix applied on soft-delete.
- **Domain / Data** — `FormField` entity, `FormFieldRepository` interface, 5 use cases, `FormFieldMapper`, `FormFieldRemoteDataSource`, `FormFieldRepositoryImpl`. `ApplicationPayload` extended with `customFields`.
- **Admin UI** — `/admin/form-fields` page with loading skeleton. `FormFieldsManagerView`: lock icons for 7 core fields, enabled/required toggles for 3 optional built-ins, full CRUD for custom fields, up/down reorder. "Form Fields" nav button added to dashboard.
- **Career microsite** — `buildApplicationFormSchema` generates Zod schema dynamically from enabled `FormField[]`. `ApplyFormView` renders fields from config. Apply page fetches form fields server-side.
- **Polish** — All admin buttons updated with `cursor-pointer` / `disabled:cursor-not-allowed`.

## Test plan

- [ ] Deploy updated `Code.gs`. Call `?action=getFormFields&companyId=X` — returns 10 seeded fields on first call.
- [ ] Create a custom field via admin UI → new column appears in Candidates sheet.
- [ ] Rename the field label → column header updated in Candidates sheet, existing data preserved.
- [ ] Delete the field → column header prefixed with `[deleted]_`, field hidden from form.
- [ ] Reorder fields → apply form reflects new order.
- [ ] Toggle optional built-in (e.g. LinkedIn URL) off → field disappears from apply form.
- [ ] Submit an application with a custom required field → value written to the new column.
- [ ] `npm run test` — all 79 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)