### PR TITLE
refactor(apps-script): organize candidate uploads into nested Drive folders

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -114,15 +114,26 @@ function openCompanyResources(slug) {
   if (!fileIter.hasNext()) throw new Error('Company database not found: ' + slug + '-database');
   var spreadsheetId = fileIter.next().getId();
 
-  var cvIter = companyDir.getFoldersByName('CVs');
-  var cvFolderId = cvIter.hasNext()
-    ? cvIter.next().getId()
-    : companyDir.createFolder('CVs').getId();
-
   return {
     spreadsheet: SpreadsheetApp.openById(spreadsheetId),
-    cvFolderId:  cvFolderId
+    companyDir:  companyDir
   };
+}
+
+function getOrCreateFolder(parentFolder, name) {
+  var iter = parentFolder.getFoldersByName(name);
+  return iter.hasNext() ? iter.next() : parentFolder.createFolder(name);
+}
+
+function findJobTitle(companySS, jobId) {
+  var sheet   = companySS.getSheetByName('Jobs');
+  var rows    = sheet.getDataRange().getValues();
+  var headers = rows[0];
+  for (var i = 1; i < rows.length; i++) {
+    var row = rowToObject(headers, rows[i]);
+    if (String(row.id) === String(jobId)) return String(row.title || 'Unknown Job');
+  }
+  return 'Unknown Job';
 }
 
 // ------------------------------------------------------------
@@ -734,9 +745,15 @@ function handleSubmitApplication(e) {
     return jsonResponse({ error: 'Missing required fields: ' + missingCustom.join(', ') }, 400);
   }
 
-  // CV upload
+  // CV upload — files are stored under {Job Title}/{timestamp} {fullName}/
+  var submissionTimestamp = new Date().toISOString();
   var cvUrl = '';
   try {
+    var jobTitle    = findJobTitle(companySS, jobId);
+    var jobFolder   = getOrCreateFolder(companyResources.companyDir, jobTitle);
+    var candFolderName = submissionTimestamp + ' ' + fullName;
+    var candFolder  = getOrCreateFolder(jobFolder, candFolderName);
+
     var cvBlob = null;
 
     // When sent as multipart, the blob may come through e.postData or via
@@ -752,9 +769,8 @@ function handleSubmitApplication(e) {
     }
 
     if (cvBlob) {
-      var folder     = DriveApp.getFolderById(companyResources.cvFolderId);
-      var cvFileName = 'CV_' + fullName.replace(/\s+/g, '_') + '_' + jobId + '_' + Date.now();
-      var cvFile     = folder.createFile(cvBlob.setName(cvFileName));
+      var cvFileName = params['cvFileName'] ? params['cvFileName'][0] : cvBlob.getName();
+      var cvFile     = candFolder.createFile(cvBlob.setName(cvFileName));
       cvFile.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
       cvUrl = cvFile.getUrl();
     }
@@ -769,7 +785,7 @@ function handleSubmitApplication(e) {
   ensureColumn(sheet, 'screening_score');
 
   var rowData = {
-    timestamp:          new Date().toISOString(),
+    timestamp:          submissionTimestamp,
     job_id:             jobId,
     company_id:         companyId,
     full_name:          fullName,

--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -43,3 +43,4 @@ Tracked issues for **WeHire**. Source of truth is GitHub Issues — this file is
 | 050 | UI revamp: Miro-inspired design system | `done` | [#50](https://github.com/handharr-labs/wehire/issues/50) |
 | 053 | Add admin-configurable form fields with dynamic Google Sheet column sync | `pending` | [#53](https://github.com/handharr-labs/wehire/issues/53) |
 | 055 | fix(design-system): establish proper design tokens, fix font setup, and unify color strategy | `pending` | [#55](https://github.com/handharr-labs/wehire/issues/55) |
+| 057 | refactor: organize candidate file uploads into nested Drive folders | `done` | [#57](https://github.com/handharr-labs/wehire/issues/57) |


### PR DESCRIPTION
## Summary
- Replaced flat `CVs/` folder with a 2-level nested structure: `{Job Title}/{ISO timestamp} {Candidate Name}/`
- Added `getOrCreateFolder` helper for idempotent folder creation
- Added `findJobTitle` to resolve job title from the Jobs sheet at submission time
- Submission timestamp computed once and reused for both the folder name and the sheet row

## Drive structure after this change
```
{slug}-dir/
└── Product Manager/
    └── 2026-04-12T14:34:18.056Z Ahmad Farhan/
        └── Ahmad_Farhan_CV.pdf
```

## Test plan
- [ ] Submit an application for a job — verify the job title folder is created under the company dir
- [ ] Verify the candidate subfolder is named `{timestamp} {fullName}`
- [ ] Verify the CV file lands inside the candidate subfolder with its original filename
- [ ] Submit a second application for the same job — verify the job folder is reused, not duplicated
- [ ] Confirm `cv_url` in the Candidates sheet still points to a valid, shareable Drive link

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)